### PR TITLE
Added escaped double quotes to cron_https_proxy variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ lint:
 		--no-only_variable_string-check \
 		--no-selector_inside_resource-check \
 		--no-variable_scope-check \
+		--no-single_quote_string_with_variables-check \
 		manifests/*.pp
 	shellcheck files/*/*.sh
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ lint:
 		--no-only_variable_string-check \
 		--no-selector_inside_resource-check \
 		--no-variable_scope-check \
-		--no-single_quote_string_with_variables-check \
 		manifests/*.pp
 	shellcheck files/*/*.sh
 

--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -21,7 +21,7 @@ class author_dispatcher (
   # TODO: see https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/6
   exec { 'deploy-artifacts.sh deploy-artifacts-descriptor.json':
     path        => ["${base_dir}/aem-tools", '/usr/bin', '/opt/puppetlabs/bin'],
-    environment => ["https_proxy=${::cron_https_proxy}"],
+    environment => ["https_proxy=\"${::cron_https_proxy}\""],
     cwd         => "${tmp_dir}",
     command     => "${base_dir}/aem-tools/deploy-artifacts.sh deploy-artifacts-descriptor.json >>/var/log/deploy-artifacts.log 2>&1",
     onlyif      => "test `aws s3 ls s3://${::data_bucket}/${::stackprefix}/deploy-artifacts-descriptor.json | wc -l` -eq 1",

--- a/manifests/author-primary.pp
+++ b/manifests/author-primary.pp
@@ -104,7 +104,7 @@ class author_primary (
     user        => 'root',
     hour        => 2,
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
   file { "${base_dir}/aem-tools/live-snapshot-backup.sh":
@@ -124,7 +124,7 @@ class author_primary (
     user        => 'root',
     hour        => '*',
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
   file { "${base_dir}/aem-tools/offline-snapshot-backup.sh":

--- a/manifests/author-primary.pp
+++ b/manifests/author-primary.pp
@@ -104,7 +104,7 @@ class author_primary (
     user        => 'root',
     hour        => 2,
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
   file { "${base_dir}/aem-tools/live-snapshot-backup.sh":
@@ -124,7 +124,7 @@ class author_primary (
     user        => 'root',
     hour        => '*',
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
   file { "${base_dir}/aem-tools/offline-snapshot-backup.sh":

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -35,7 +35,7 @@ class orchestrator (
     user        => 'root',
     hour        => 1,
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
 }

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -35,7 +35,7 @@ class orchestrator (
     user        => 'root',
     hour        => 1,
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
 }

--- a/manifests/promote-author-standby-to-primary.pp
+++ b/manifests/promote-author-standby-to-primary.pp
@@ -38,7 +38,7 @@ class promote_author_standby_to_primary (
     user        => 'root',
     hour        => 2,
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
   cron { 'hourly-live-snapshot-backup':
@@ -46,7 +46,7 @@ class promote_author_standby_to_primary (
     user        => 'root',
     hour        => '*',
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
 }

--- a/manifests/promote-author-standby-to-primary.pp
+++ b/manifests/promote-author-standby-to-primary.pp
@@ -38,7 +38,7 @@ class promote_author_standby_to_primary (
     user        => 'root',
     hour        => 2,
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
   cron { 'hourly-live-snapshot-backup':
@@ -46,7 +46,7 @@ class promote_author_standby_to_primary (
     user        => 'root',
     hour        => '*',
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
 }

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -22,7 +22,7 @@ class publish_dispatcher (
   # TODO: see https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/6
   exec { 'deploy-artifacts.sh deploy-artifacts-descriptor.json':
     path        => ["${base_dir}/aem-tools", '/usr/bin', '/opt/puppetlabs/bin'],
-    environment => ["https_proxy=${::cron_https_proxy}"],
+    environment => ["https_proxy=\"${::cron_https_proxy}\""],
     cwd         => "${tmp_dir}",
     command     => "${base_dir}/aem-tools/deploy-artifacts.sh deploy-artifacts-descriptor.json >>/var/log/deploy-artifacts.log 2>&1",
     onlyif      => "test `aws s3 ls s3://${::data_bucket}/${::stackprefix}/deploy-artifacts-descriptor.json | wc -l` -eq 1",
@@ -66,7 +66,7 @@ class publish_dispatcher (
     command     => "${base_dir}/aem-tools/content-healthcheck.py",
     user        => 'root',
     minute      => '*',
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
 }

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -66,7 +66,7 @@ class publish_dispatcher (
     command     => "${base_dir}/aem-tools/content-healthcheck.py",
     user        => 'root',
     minute      => '*',
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
 }

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -111,7 +111,7 @@ class publish (
     user        => 'root',
     hour        => 2,
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
     require     => File["${base_dir}/aem-tools/export-backups.sh"],
   }
 
@@ -132,7 +132,7 @@ class publish (
     user        => 'root',
     hour        => '*',
     minute      => 0,
-    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
+    environment => ["PATH=${::cron_env_path}", "https_proxy=\"${::cron_https_proxy}\""],
   }
 
   file { "${base_dir}/aem-tools/offline-snapshot-backup.sh":

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -111,7 +111,7 @@ class publish (
     user        => 'root',
     hour        => 2,
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
     require     => File["${base_dir}/aem-tools/export-backups.sh"],
   }
 
@@ -132,7 +132,7 @@ class publish (
     user        => 'root',
     hour        => '*',
     minute      => 0,
-    environment => ["PATH=${::cron_env_path}", "https_proxy=${::cron_https_proxy}"],
+    environment => ['PATH=${::cron_env_path}', 'https_proxy=${::cron_https_proxy}'],
   }
 
   file { "${base_dir}/aem-tools/offline-snapshot-backup.sh":


### PR DESCRIPTION
*Changed double quotes to single quotes in all the cron environments, since it seemed to be generating an error and the cron job was not being generated