### PR TITLE
Enhancement/add aem tool flush dispatcher cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.4.3
 * Add support to promote author standby as primary instance
 * Add AEM ID tag to AMIs produced by live and offline snapshot backups #58
+* Modify passing of parameter docroot_dir
 
 ### 2.4.2
 * Upgrade Puppet SimianArmy to 1.1.1 to handle empty proxy configuration

--- a/data/author-dispatcher.yaml
+++ b/data/author-dispatcher.yaml
@@ -1,7 +1,5 @@
 ---
 author_dispatcher::base_dir: "%{hiera('common::base_dir')}"
-author_dispatcher::docroot_dir: /var/www/html/
-
 
 aem_curator::config_author_dispatcher::base_dir: "%{hiera('common::base_dir')}"
 aem_curator::config_author_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"

--- a/data/author-dispatcher.yaml
+++ b/data/author-dispatcher.yaml
@@ -1,11 +1,12 @@
 ---
 author_dispatcher::base_dir: "%{hiera('common::base_dir')}"
+author_dispatcher::docroot_dir: /var/www/html/
+
 
 aem_curator::config_author_dispatcher::base_dir: "%{hiera('common::base_dir')}"
 aem_curator::config_author_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_author_dispatcher::dispatcher_conf_dir: /etc/httpd/conf.modules.d/
 aem_curator::config_author_dispatcher::httpd_conf_dir: /etc/httpd/conf.d/
-aem_curator::config_author_dispatcher::docroot_dir: /var/www/html/
 aem_curator::config_author_dispatcher::ssl_cert: /etc/ssl/aem.unified-dispatcher.cert
 aem_curator::config_author_dispatcher::author_host: localhost
 # Author ELB is listening on port 80/443 due to AEM using X-Forwarded-Port to construct location header

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -88,7 +88,6 @@ aem_curator::config_publish::aem_password_reset_version: '1.0.2'
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::dispatcher_conf_dir: /etc/httpd/conf.modules.d/
 aem_curator::config_publish_dispatcher::httpd_conf_dir: /etc/httpd/conf.d/
-aem_curator::config_publish_dispatcher::docroot_dir: /var/www/html/
 aem_curator::config_publish_dispatcher::ssl_cert: /etc/ssl/aem.unified-dispatcher.cert
 aem_curator::config_publish_dispatcher::publish_host: localhost
 aem_curator::config_publish_dispatcher::publish_port: 5433

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -21,6 +21,7 @@ common::tmp_base_dir: /tmp/shinesolutions
 common::tmp_dir: /tmp/shinesolutions/aem-aws-stack-provisioner
 common::puppet_conf_dir: /etc/puppetlabs/puppet/
 common::credentials_file: system-users-credentials.json
+common::docroot_dir: /var/www/html/
 
 author::exec_path: "%{alias('exec_path')}"
 publish::exec_path: "%{alias('exec_path')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -70,6 +70,9 @@ aem_curator::action_deploy_artifacts::dispatcher_conf_dir: /etc/httpd/conf.d
 aem_curator::action_deploy_artifacts::static_assets_dir: /var/www/html
 aem_curator::action_deploy_artifacts::virtual_hosts_dir: /etc/httpd/conf.d
 
+# AEM-Tool Flush-Dispatcher-cache
+aem_curator::action_flush_dispatcher_cache::docroot_dir: "%{hiera('common::docroot_dir')}"
+
 # AEM Author Primary and Standby configuration and promotion
 aem_curator::config_author_primary::aem_version: '6.2'
 aem_curator::config_author_standby::aem_version: '6.2'

--- a/data/publish-dispatcher.yaml
+++ b/data/publish-dispatcher.yaml
@@ -1,6 +1,5 @@
 ---
 publish_dispatcher::base_dir: "%{hiera('common::base_dir')}"
-publish_dispatcher::docroot_dir: /var/www/html/
 
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::dispatcher_conf_dir: /etc/httpd/conf.modules.d/

--- a/data/publish-dispatcher.yaml
+++ b/data/publish-dispatcher.yaml
@@ -1,10 +1,10 @@
 ---
 publish_dispatcher::base_dir: "%{hiera('common::base_dir')}"
+publish_dispatcher::docroot_dir: /var/www/html/
 
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::dispatcher_conf_dir: /etc/httpd/conf.modules.d/
 aem_curator::config_publish_dispatcher::httpd_conf_dir: /etc/httpd/conf.d/
-aem_curator::config_publish_dispatcher::docroot_dir: /var/www/html/
 aem_curator::config_publish_dispatcher::ssl_cert: /etc/ssl/aem.unified-dispatcher.cert
 aem_curator::config_publish_dispatcher::publish_host: localhost
 aem_curator::config_publish_dispatcher::publish_port: 5433

--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -9,6 +9,7 @@ class author_dispatcher (
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
+    base_dir    => $base_dir,
     docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_dispatcher':

--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -4,16 +4,13 @@ File {
 
 class author_dispatcher (
   $base_dir,
-  $docroot_dir,
   $author_host = $::authorhost,
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
-    docroot_dir    => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_dispatcher':
     author_host => $author_host,
-    docroot_dir => $docroot_dir,
   }
 
   ##############################################################################

--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -10,7 +10,6 @@ class author_dispatcher (
 
   class { 'aem_curator::config_aem_tools_dispatcher':
     base_dir    => $base_dir,
-    docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_dispatcher':
     author_host => $author_host,

--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -4,17 +4,16 @@ File {
 
 class author_dispatcher (
   $base_dir,
+  $docroot_dir,
   $author_host = $::authorhost,
 ) {
 
-  file { "${base_dir}/aem-tools/":
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'root',
-    group  => 'root',
+  class { 'aem_curator::config_aem_tools_dispatcher':
+    docroot_dir    => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_dispatcher':
     author_host => $author_host,
+    docroot_dir => $docroot_dir,
   }
 
   ##############################################################################

--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -5,12 +5,15 @@ File {
 class author_dispatcher (
   $base_dir,
   $author_host = $::authorhost,
+  $docroot_dir = lookup('common::docroot_dir'),
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
+    docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_dispatcher':
     author_host => $author_host,
+    docroot_dir => $docroot_dir,
   }
 
   ##############################################################################

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -27,7 +27,6 @@ class author_publish_dispatcher (
   class { 'aem_curator::config_aem_tools':
   } -> class { 'aem_curator::config_aem_tools_dispatcher':
     base_dir    => $base_dir,
-    docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_primary':
   } -> class { 'aem_curator::config_publish':

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -25,6 +25,9 @@ class author_publish_dispatcher (
   $credentials_hash = loadjson("${tmp_dir}/${credentials_file}")
 
   class { 'aem_curator::config_aem_tools':
+  } -> class { 'aem_curator::config_aem_tools_dispatcher':
+    base_dir    => $base_dir,
+    docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_author_primary':
   } -> class { 'aem_curator::config_publish':

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -18,6 +18,7 @@ class author_publish_dispatcher (
   $env_path              = $::cron_env_path,
   $https_proxy           = $::cron_https_proxy,
   $aem_id_author_primary = 'author-primary',
+  $docroot_dir           = lookup('common::docroot_dir'),
   $ec2_id                = $::ec2_metadata['instance-id'],
 ) {
 
@@ -28,6 +29,7 @@ class author_publish_dispatcher (
   } -> class { 'aem_curator::config_author_primary':
   } -> class { 'aem_curator::config_publish':
   } -> class { 'aem_curator::config_publish_dispatcher':
+    docroot_dir => $docroot_dir,
   } -> aem_replication_agent { 'Create replication agent':
     ensure             => present,
     aem_username       => 'admin',

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -5,6 +5,7 @@ File {
 class publish_dispatcher (
   $base_dir,
   $allowed_client = $::publish_dispatcher_allowed_client,
+  $docroot_dir    = lookup('common::docroot_dir'),
   $publish_host   = $::publishhost,
   $stack_prefix   = $::stack_prefix,
   $data_bucket    = $::data_bucket,
@@ -13,11 +14,12 @@ class publish_dispatcher (
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
-    base_dir    => $base_dir,
+    docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,
     publish_host   => $publish_host,
+    docroot_dir    => $docroot_dir,
   }
 
   file { "${base_dir}/aem-tools/content-healthcheck.py":

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -4,7 +4,6 @@ File {
 
 class publish_dispatcher (
   $base_dir,
-  $docroot_dir,
   $allowed_client = $::publish_dispatcher_allowed_client,
   $publish_host   = $::publishhost,
   $stack_prefix   = $::stack_prefix,
@@ -14,13 +13,11 @@ class publish_dispatcher (
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
-    docroot_dir => $docroot_dir,
     base_dir    => $base_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,
     publish_host   => $publish_host,
-    docroot_dir    => $docroot_dir,
   }
 
   file { "${base_dir}/aem-tools/content-healthcheck.py":

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -14,6 +14,7 @@ class publish_dispatcher (
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
+    base_dir    => $base_dir,
     docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -4,6 +4,7 @@ File {
 
 class publish_dispatcher (
   $base_dir,
+  $docroot_dir,
   $allowed_client = $::publish_dispatcher_allowed_client,
   $publish_host   = $::publishhost,
   $stack_prefix   = $::stack_prefix,
@@ -12,15 +13,13 @@ class publish_dispatcher (
   $https_proxy    = $::cron_https_proxy,
 ) {
 
-  file { "${base_dir}/aem-tools/":
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'root',
-    group  => 'root',
+  class { 'aem_curator::config_aem_tools_dispatcher':
+    docroot_dir    => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,
     publish_host   => $publish_host,
+    docroot_dir    => $docroot_dir,
   }
 
   file { "${base_dir}/aem-tools/content-healthcheck.py":

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -15,7 +15,7 @@ class publish_dispatcher (
 
   class { 'aem_curator::config_aem_tools_dispatcher':
     docroot_dir    => $docroot_dir,
-    base_dir      => $base_dir,
+    base_dir       => $base_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -15,6 +15,7 @@ class publish_dispatcher (
 
   class { 'aem_curator::config_aem_tools_dispatcher':
     docroot_dir    => $docroot_dir,
+    base_dir      => $base_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -15,7 +15,6 @@ class publish_dispatcher (
 
   class { 'aem_curator::config_aem_tools_dispatcher':
     base_dir    => $base_dir,
-    docroot_dir => $docroot_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -14,8 +14,8 @@ class publish_dispatcher (
 ) {
 
   class { 'aem_curator::config_aem_tools_dispatcher':
-    docroot_dir    => $docroot_dir,
-    base_dir       => $base_dir,
+    docroot_dir => $docroot_dir,
+    base_dir    => $base_dir,
   } -> class { 'aem_curator::config_aem_deployer':
   } -> class { 'aem_curator::config_publish_dispatcher':
     allowed_client => $allowed_client,


### PR DESCRIPTION
* Modified the passing of the parameter docroot_dir for dispatcher instances.
* Added requirements for own manifest for Dispatcher instances to configure their own AEM Tools

https://github.com/shinesolutions/aem-stack-manager-cloud/issues/9