### PR TITLE
Fixed inspec syntax for orchestrator inspec test

### DIFF
--- a/test/inspec/orchestrator_spec.rb
+++ b/test/inspec/orchestrator_spec.rb
@@ -1,15 +1,15 @@
 require_relative './spec_helper'
 
-describe service('aem-orchestrator') do
-  if os[:family] != 'amazon'
+if !os[:family].eql? 'amazon'
+  describe service('aem-orchestrator') do
     # This check doesn't work on Amazon Linux because it doesn't check for
     # Upstart services.
     it { should be_enabled }
+    it { should be_running }
   end
-  it { should be_running }
 end
 
-if os[:family] == 'amazon'
+if os[:family].eql? 'amazon'
   describe command('/opt/puppetlabs/bin/puppet resource service aem-orchestrator ') do
     its(:stdout) { should match 'enable => \'true\'' }
   end


### PR DESCRIPTION
Fixed inspec syntax for orchestrator inspec test.

See issue: https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/70