### PR TITLE
Enhancement/cron configuration

### DIFF
--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -69,7 +69,7 @@ aem_curator::config_author_primary::enable_default_passwords: false
 aem_curator::config_author_primary::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_author_primary::aem_password_reset_version')}.zip"
 aem_curator::config_author_primary::aem_password_reset_version: '1.0.2'
 
-aem_curator::config_aem_cronjobs::cron_offline_compaction_enable: "%{hiera('author_primary::cron_offline_compaction_enable')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_day: "%{hiera('author_primary::cron_offline_compaction_day')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_hour: "%{hiera('author_primary::cron_offline_compaction_hour')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_minute: "%{hiera('author_primary::cron_offline_compaction_minute')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{hiera('author_primary::cron_offline_compaction_enable')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('author_primary::cron_offline_compaction_day')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('author_primary::cron_offline_compaction_hour')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('author_primary::cron_offline_compaction_minute')}"

--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -8,6 +8,15 @@ author_primary::aem_repo_devices:
 
 author_primary::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
+config_scheduled_jobs::cron_export_enable: "%{hiera('author_primary::cron_export_enable')}"
+config_scheduled_jobs::cron_export_hour: "%{hiera('author_primary::cron_export_hour')}"
+config_scheduled_jobs::cron_export_minute: "%{hiera('author_primary::cron_export_minute')}"
+config_scheduled_jobs::cron_export_weekday: "%{hiera('author_primary::cron_export_weekday')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('author_primary::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('author_primary::cron_live_snapshot_hour')}"
+config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('author_primary::cron_live_snapshot_minute')}"
+config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('author_primary::cron_live_snapshot_weekday')}"
+
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author
     aem_id: "%{hiera('author_primary::aem_id')}"
@@ -36,9 +45,6 @@ aem_curator::action_import_backup::aem_id: "%{hiera('author_primary::aem_id')}"
 
 aem_curator::action_promote_author_standby_to_primary::base_dir: "%{hiera('common::base_dir')}"
 aem_curator::action_promote_author_standby_to_primary::tmp_dir: "%{hiera('common::tmp_dir')}"
-aem_curator::action_promote_author_standby_to_primary::enable_offline_compaction_cron: false
-aem_curator::action_promote_author_standby_to_primary::enable_daily_export_cron: false
-aem_curator::action_promote_author_standby_to_primary::enable_hourly_live_snapshot_cron: false
 
 aem_curator::config_aem_tools::aem_instances:
   - crx_quickstart_dir: /opt/aem/author/crx-quickstart
@@ -58,10 +64,12 @@ aem_curator::config_author_primary::author_protocol: http
 aem_curator::config_author_primary::author_port: 4502
 aem_curator::config_author_primary::credentials_file: "%{hiera('common::credentials_file')}"
 aem_curator::config_author_primary::enable_deploy_flag: false
-aem_curator::config_author_primary::enable_offline_compaction_cron: false
-aem_curator::config_author_primary::enable_daily_export_cron: false
-aem_curator::config_author_primary::enable_hourly_live_snapshot_cron: false
 aem_curator::config_author_primary::enable_crxde: false
 aem_curator::config_author_primary::enable_default_passwords: false
 aem_curator::config_author_primary::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_author_primary::aem_password_reset_version')}.zip"
 aem_curator::config_author_primary::aem_password_reset_version: '1.0.2'
+
+aem_curator::config_aem_cronjobs::cron_offline_compaction_enable: "%{hiera('author_primary::cron_offline_compaction_enable')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_day: "%{hiera('author_primary::cron_offline_compaction_day')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_hour: "%{hiera('author_primary::cron_offline_compaction_hour')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_minute: "%{hiera('author_primary::cron_offline_compaction_minute')}"

--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -9,14 +9,14 @@ author_primary::aem_repo_devices:
 
 author_primary::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
-config_scheduled_jobs::cron_export_enable: "%{alias('author_primary::cron_export_enable')}"
-config_scheduled_jobs::cron_export_hour: "%{hiera('author_primary::cron_export_hour')}"
-config_scheduled_jobs::cron_export_minute: "%{hiera('author_primary::cron_export_minute')}"
-config_scheduled_jobs::cron_export_weekday: "%{hiera('author_primary::cron_export_weekday')}"
-config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('author_primary::cron_live_snapshot_enable')}"
-config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('author_primary::cron_live_snapshot_hour')}"
-config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('author_primary::cron_live_snapshot_minute')}"
-config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('author_primary::cron_live_snapshot_weekday')}"
+scheduled_jobs::export_enable: "%{alias('author_primary::scheduled_jobs::enable::export')}"
+scheduled_jobs::export_weekday: "%{hiera('author_primary::scheduled_jobs::weekday::export')}"
+scheduled_jobs::export_hour: "%{hiera('author_primary::scheduled_jobs::hour::export')}"
+scheduled_jobs::export_minute: "%{hiera('author_primary::scheduled_jobs::minute::export')}"
+scheduled_jobs::live_snapshot_enable: "%{alias('author_primary::scheduled_jobs::enable::live_snapshot')}"
+scheduled_jobs::live_snapshot_weekday: "%{hiera('author_primary::scheduled_jobs::weekday::live_snapshot')}"
+scheduled_jobs::live_snapshot_hour: "%{hiera('author_primary::scheduled_jobs::hour::live_snapshot')}"
+scheduled_jobs::live_snapshot_minute: "%{hiera('author_primary::scheduled_jobs::minute::live_snapshot')}"
 
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author
@@ -70,7 +70,7 @@ aem_curator::config_author_primary::enable_default_passwords: false
 aem_curator::config_author_primary::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_author_primary::aem_password_reset_version')}.zip"
 aem_curator::config_author_primary::aem_password_reset_version: '1.0.2'
 
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{alias('author_primary::cron_offline_compaction_enable')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('author_primary::cron_offline_compaction_day')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('author_primary::cron_offline_compaction_hour')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('author_primary::cron_offline_compaction_minute')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('author_primary::scheduled_jobs::aem::enable::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('author_primary::scheduled_jobs::aem::weekday::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_hour: "%{hiera('author_primary::scheduled_jobs::aem::hour::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_minute: "%{hiera('author_primary::scheduled_jobs::aem::minute::offline_compaction')}"

--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -9,11 +9,11 @@ author_primary::aem_repo_devices:
 
 author_primary::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
-config_scheduled_jobs::cron_export_enable: "%{hiera('author_primary::cron_export_enable')}"
+config_scheduled_jobs::cron_export_enable: "%{alias('author_primary::cron_export_enable')}"
 config_scheduled_jobs::cron_export_hour: "%{hiera('author_primary::cron_export_hour')}"
 config_scheduled_jobs::cron_export_minute: "%{hiera('author_primary::cron_export_minute')}"
 config_scheduled_jobs::cron_export_weekday: "%{hiera('author_primary::cron_export_weekday')}"
-config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('author_primary::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('author_primary::cron_live_snapshot_enable')}"
 config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('author_primary::cron_live_snapshot_hour')}"
 config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('author_primary::cron_live_snapshot_minute')}"
 config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('author_primary::cron_live_snapshot_weekday')}"
@@ -70,7 +70,7 @@ aem_curator::config_author_primary::enable_default_passwords: false
 aem_curator::config_author_primary::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_author_primary::aem_password_reset_version')}.zip"
 aem_curator::config_author_primary::aem_password_reset_version: '1.0.2'
 
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{hiera('author_primary::cron_offline_compaction_enable')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{alias('author_primary::cron_offline_compaction_enable')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('author_primary::cron_offline_compaction_day')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('author_primary::cron_offline_compaction_hour')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('author_primary::cron_offline_compaction_minute')}"

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -1,5 +1,4 @@
 ---
-
 # AEM Author Publish Dispatcher
 author_publish_dispatcher::base_dir: "%{hiera('common::base_dir')}"
 author_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
@@ -16,6 +15,15 @@ author_publish_dispatcher::aem_repo_devices:
 author_publish_dispatcher::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 author_publish_dispatcher::enable_daily_export_cron: false
 author_publish_dispatcher::enable_hourly_live_snapshot_cron: false
+
+config_scheduled_jobs::cron_export_enable: "%{hiera('publish::cron_export_enable')}"
+config_scheduled_jobs::cron_export_hour: "%{hiera('publish::cron_export_hour')}"
+config_scheduled_jobs::cron_export_minute: "%{hiera('publish::cron_export_minute')}"
+config_scheduled_jobs::cron_export_weekday: "%{hiera('publish::cron_export_weekday')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('publish::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('publish::cron_live_snapshot_hour')}"
+config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('publish::cron_live_snapshot_minute')}"
+config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('publish::cron_live_snapshot_weekday')}"
 
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author
@@ -34,7 +42,7 @@ aem_curator::action_list_packages::aem_instances:
     aem_id: author
   - run_mode: publish
     aem_id: publish
-    
+
 aem_curator::action_deploy_artifacts::author_host: "%{hiera('common::author_host')}"
 aem_curator::action_deploy_artifacts::publish_host: "%{hiera('common::publish_host')}"
 
@@ -71,9 +79,6 @@ aem_curator::config_author_primary::author_protocol: http
 aem_curator::config_author_primary::author_port: 4502
 aem_curator::config_author_primary::credentials_file: "%{hiera('common::credentials_file')}"
 aem_curator::config_author_primary::enable_deploy_flag: false
-aem_curator::config_author_primary::enable_offline_compaction_cron: false
-aem_curator::config_author_primary::enable_daily_export_cron: false
-aem_curator::config_author_primary::enable_hourly_live_snapshot_cron: false
 aem_curator::config_author_primary::enable_crxde: false
 aem_curator::config_author_primary::enable_default_passwords: false
 aem_curator::config_author_primary::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_author_primary::aem_password_reset_version')}.zip"
@@ -93,9 +98,6 @@ aem_curator::config_publish::enable_deploy_flag: false
 aem_curator::config_publish::login_ready_max_tries: 60
 aem_curator::config_publish::login_ready_base_sleep_seconds: 5
 aem_curator::config_publish::login_ready_max_sleep_seconds: 5
-aem_curator::config_publish::enable_offline_compaction_cron: false
-aem_curator::config_publish::enable_daily_export_cron: false
-aem_curator::config_publish::enable_hourly_live_snapshot_cron: false
 aem_curator::config_publish::enable_crxde: false
 aem_curator::config_publish::enable_default_passwords: false
 aem_curator::config_publish::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_publish::aem_password_reset_version')}.zip"
@@ -110,3 +112,8 @@ aem_curator::config_publish_dispatcher::publish_secure: "%{hiera('common::publis
 aem_curator::config_publish_dispatcher::ssl_cert: "%{hiera('common::dispatcher_ssl_cert')}"
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::virtual_hosts_dir: "%{hiera('common::virtual_hosts_dir')}"
+
+aem_curator::config_aem_cronjobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -113,7 +113,7 @@ aem_curator::config_publish_dispatcher::ssl_cert: "%{hiera('common::dispatcher_s
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::virtual_hosts_dir: "%{hiera('common::virtual_hosts_dir')}"
 
-aem_curator::config_aem_cronjobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -16,14 +16,12 @@ author_publish_dispatcher::aem_repo_devices:
 author_publish_dispatcher::volume_type: gp2
 
 author_publish_dispatcher::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
-author_publish_dispatcher::enable_daily_export_cron: false
-author_publish_dispatcher::enable_hourly_live_snapshot_cron: false
 
-config_scheduled_jobs::cron_export_enable: "%{hiera('publish::cron_export_enable')}"
+config_scheduled_jobs::cron_export_enable: "%{alias('publish::cron_export_enable')}"
 config_scheduled_jobs::cron_export_hour: "%{hiera('publish::cron_export_hour')}"
 config_scheduled_jobs::cron_export_minute: "%{hiera('publish::cron_export_minute')}"
 config_scheduled_jobs::cron_export_weekday: "%{hiera('publish::cron_export_weekday')}"
-config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('publish::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('publish::cron_live_snapshot_enable')}"
 config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('publish::cron_live_snapshot_hour')}"
 config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('publish::cron_live_snapshot_minute')}"
 config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('publish::cron_live_snapshot_weekday')}"
@@ -115,7 +113,7 @@ aem_curator::config_publish_dispatcher::ssl_cert: "%{hiera('common::dispatcher_s
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::virtual_hosts_dir: "%{hiera('common::virtual_hosts_dir')}"
 
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{alias('publish::cron_offline_compaction_enable')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -17,14 +17,14 @@ author_publish_dispatcher::volume_type: gp2
 
 author_publish_dispatcher::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
-config_scheduled_jobs::cron_export_enable: "%{alias('publish::cron_export_enable')}"
-config_scheduled_jobs::cron_export_hour: "%{hiera('publish::cron_export_hour')}"
-config_scheduled_jobs::cron_export_minute: "%{hiera('publish::cron_export_minute')}"
-config_scheduled_jobs::cron_export_weekday: "%{hiera('publish::cron_export_weekday')}"
-config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('publish::cron_live_snapshot_enable')}"
-config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('publish::cron_live_snapshot_hour')}"
-config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('publish::cron_live_snapshot_minute')}"
-config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('publish::cron_live_snapshot_weekday')}"
+scheduled_jobs::export_enable: "%{alias('publish::scheduled_jobs::enable::export')}"
+scheduled_jobs::export_weekday: "%{hiera('publish::scheduled_jobs::weekday::export')}"
+scheduled_jobs::export_hour: "%{hiera('publish::scheduled_jobs::hour::export')}"
+scheduled_jobs::export_minute: "%{hiera('publish::scheduled_jobs::minute::export')}"
+scheduled_jobs::live_snapshot_enable: "%{alias('publish::scheduled_jobs::enable::live_snapshot')}"
+scheduled_jobs::live_snapshot_weekday: "%{hiera('publish::scheduled_jobs::weekday::live_snapshot')}"
+scheduled_jobs::live_snapshot_hour: "%{hiera('publish::scheduled_jobs::hour::live_snapshot')}"
+scheduled_jobs::live_snapshot_minute: "%{hiera('publish::scheduled_jobs::minute::live_snapshot')}"
 
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author
@@ -113,7 +113,7 @@ aem_curator::config_publish_dispatcher::ssl_cert: "%{hiera('common::dispatcher_s
 aem_curator::config_publish_dispatcher::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_publish_dispatcher::virtual_hosts_dir: "%{hiera('common::virtual_hosts_dir')}"
 
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{alias('publish::cron_offline_compaction_enable')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('publish::scheduled_jobs::aem::enable::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('publish::scheduled_jobs::aem::weekday::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_hour: "%{hiera('publish::scheduled_jobs::aem::hour::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_minute: "%{hiera('publish::scheduled_jobs::aem::minute::offline_compaction')}"

--- a/data/author-standby.yaml
+++ b/data/author-standby.yaml
@@ -7,10 +7,10 @@ author_standby::aem_repo_devices:
     device_alias: /dev/xvdb
     aem_id: "%{hiera('author_standby::aem_id')}"
 
-config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('author_standby::cron_live_snapshot_enable')}"
-config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('author_standby::cron_live_snapshot_hour')}"
-config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('author_standby::cron_live_snapshot_minute')}"
-config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('author_standby::cron_live_snapshot_weekday')}"
+scheduled_jobs::live_snapshot_enable: "%{alias('author_standby::scheduled_jobs::enable::live_snapshot')}"
+scheduled_jobs::live_snapshot_weekday: "%{hiera('author_standby::scheduled_jobs::weekday::live_snapshot')}"
+scheduled_jobs::live_snapshot_hour: "%{hiera('author_standby::scheduled_jobs::hour::live_snapshot')}"
+scheduled_jobs::live_snapshot_minute: "%{hiera('author_standby::scheduled_jobs::minute::live_snapshot')}"
 
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author

--- a/data/author-standby.yaml
+++ b/data/author-standby.yaml
@@ -7,7 +7,7 @@ author_standby::aem_repo_devices:
     device_alias: /dev/xvdb
     aem_id: "%{hiera('author_standby::aem_id')}"
 
-config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('author_standby::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('author_standby::cron_live_snapshot_enable')}"
 config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('author_standby::cron_live_snapshot_hour')}"
 config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('author_standby::cron_live_snapshot_minute')}"
 config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('author_standby::cron_live_snapshot_weekday')}"

--- a/data/author-standby.yaml
+++ b/data/author-standby.yaml
@@ -6,6 +6,11 @@ author_standby::aem_repo_devices:
   - device_name: /dev/sdb
     aem_id: "%{hiera('author_standby::aem_id')}"
 
+config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('author_standby::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('author_standby::cron_live_snapshot_hour')}"
+config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('author_standby::cron_live_snapshot_minute')}"
+config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('author_standby::cron_live_snapshot_weekday')}"
+
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author
     aem_id: "%{hiera('author_standby::aem_id')}"
@@ -34,9 +39,6 @@ aem_curator::action_import_backup::aem_id: "%{hiera('author_standby::aem_id')}"
 
 aem_curator::action_promote_author_standby_to_primary::base_dir: "%{hiera('common::base_dir')}"
 aem_curator::action_promote_author_standby_to_primary::tmp_dir: "%{hiera('common::tmp_dir')}"
-aem_curator::action_promote_author_standby_to_primary::enable_offline_compaction_cron: false
-aem_curator::action_promote_author_standby_to_primary::enable_daily_export_cron: false
-aem_curator::action_promote_author_standby_to_primary::enable_hourly_live_snapshot_cron: false
 
 aem_curator::config_aem_tools::aem_instances:
   - crx_quickstart_dir: /opt/aem/author/crx-quickstart
@@ -56,8 +58,5 @@ aem_curator::config_author_standby::author_protocol: http
 aem_curator::config_author_standby::author_port: 4502
 aem_curator::config_author_standby::credentials_file: "%{hiera('common::credentials_file')}"
 aem_curator::config_author_standby::enable_deploy_flag: false
-aem_curator::config_author_standby::enable_offline_compaction_cron: false
-aem_curator::config_author_standby::enable_daily_export_cron: false
-aem_curator::config_author_standby::enable_hourly_live_snapshot_cron: false
 aem_curator::config_author_standby::enable_crxde: false
 aem_curator::config_author_standby::enable_default_passwords: false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,8 +40,8 @@ common::dispatcher_ssl_cert: /etc/ssl/aem.unified-dispatcher.cert
 
 common::aem_password_retrieval_command: "aws s3 cp s3://%{::data_bucket_name}/%{::stack_prefix}/system-users-credentials.json - | jq --raw-output .$aem_username"
 
-# AEM AWS Cronjobs
-config_scheduled_jobs::base_dir: "%{hiera('common::base_dir')}"
+# AEM AWS scheduled jobs
+scheduled_jobs::base_dir: "%{hiera('common::base_dir')}"
 
 author::exec_path: "%{alias('exec_path')}"
 publish::exec_path: "%{alias('exec_path')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,6 +40,9 @@ common::dispatcher_ssl_cert: /etc/ssl/aem.unified-dispatcher.cert
 
 common::aem_password_retrieval_command: "aws s3 cp s3://%{::data_bucket_name}/%{::stack_prefix}/system-users-credentials.json - | jq --raw-output .$aem_username"
 
+# AEM AWS Cronjobs
+config_scheduled_jobs::base_dir: "%{hiera('common::base_dir')}"
+
 author::exec_path: "%{alias('exec_path')}"
 publish::exec_path: "%{alias('exec_path')}"
 author_dispatcher::exec_path: "%{alias('exec_path')}"
@@ -49,19 +52,12 @@ aem_curator::config_publish::exec_path: "%{alias('exec_path')}"
 aem_curator::config_author_dispatcher::exec_path: "%{alias('exec_path')}"
 aem_curator::config_publish_dispatcher::exec_path: "%{alias('exec_path')}"
 
-author_primary::enable_offline_compaction_cron: false
-author_primary::enable_daily_export_cron: false
-author_primary::enable_hourly_live_snapshot_cron: false
-
-author_standby::enable_hourly_live_snapshot_cron: false
-
-publish::enable_offline_compaction_cron: false
-publish::enable_daily_export_cron: false
-publish::enable_hourly_live_snapshot_cron: false
-
 publish::login_ready_max_tries: 60
 publish::login_ready_base_sleep_seconds: 5
 publish::login_ready_max_sleep_seconds: 5
+
+# AEM Cronjobs
+aem_curator::config_aem_cronjobs::base_dir: "%{hiera('common::base_dir')}"
 
 # AEM Tools
 aem_curator::config_aem_tools::oak_run_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/oak-run-%{hiera('aem_curator::config_aem_tools::oak_run_version')}.jar"
@@ -70,7 +66,6 @@ aem_curator::config_aem_tools::aem_password_retrieval_command: "%{hiera('common:
 aem_curator::config_aem_tools::base_dir: "%{hiera('common::base_dir')}"
 aem_curator::config_aem_tools::tmp_dir: "%{hiera('common::tmp_dir')}"
 aem_curator::config_aem_tools::aem_repo_device: /dev/sdb
-aem_curator::config_aem_tools::enable_offline_compaction_cron: false
 aem_curator::config_aem_tools_dispatcher::base_dir: "%{hiera('common::base_dir')}"
 
 # AEM Deployer

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -57,7 +57,7 @@ publish::login_ready_base_sleep_seconds: 5
 publish::login_ready_max_sleep_seconds: 5
 
 # AEM Cronjobs
-aem_curator::config_aem_cronjobs::base_dir: "%{hiera('common::base_dir')}"
+aem_curator::config_aem_scheduled_jobs::base_dir: "%{hiera('common::base_dir')}"
 
 # AEM Tools
 aem_curator::config_aem_tools::oak_run_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/oak-run-%{hiera('aem_curator::config_aem_tools::oak_run_version')}.jar"

--- a/data/orchestrator.yaml
+++ b/data/orchestrator.yaml
@@ -2,8 +2,8 @@
 orchestrator::base_dir: "%{hiera('common::base_dir')}"
 orchestrator::aem_orchestrator_version: 1.0.0
 
-config_scheduled_jobs::cron_offline_compaction_snapshot_enable: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_enable')}"
-config_scheduled_jobs::cron_offline_snapshot_enable: "%{hiera('aem_orchestrator::cron_offline_snapshot_enable')}"
+config_scheduled_jobs::cron_offline_compaction_snapshot_enable: "%{alias('aem_orchestrator::cron_offline_compaction_snapshot_enable')}"
+config_scheduled_jobs::cron_offline_snapshot_enable: "%{alias('aem_orchestrator::cron_offline_snapshot_enable')}"
 config_scheduled_jobs::cron_offline_compaction_snapshot_hour: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_hour')}"
 config_scheduled_jobs::cron_offline_compaction_snapshot_minute: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_minute')}"
 config_scheduled_jobs::cron_offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_weekday')}"

--- a/data/orchestrator.yaml
+++ b/data/orchestrator.yaml
@@ -2,14 +2,14 @@
 orchestrator::base_dir: "%{hiera('common::base_dir')}"
 orchestrator::aem_orchestrator_version: 1.0.0
 
-config_scheduled_jobs::cron_offline_compaction_snapshot_enable: "%{alias('aem_orchestrator::cron_offline_compaction_snapshot_enable')}"
-config_scheduled_jobs::cron_offline_snapshot_enable: "%{alias('aem_orchestrator::cron_offline_snapshot_enable')}"
-config_scheduled_jobs::cron_offline_compaction_snapshot_hour: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_hour')}"
-config_scheduled_jobs::cron_offline_compaction_snapshot_minute: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_minute')}"
-config_scheduled_jobs::cron_offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_weekday')}"
-config_scheduled_jobs::cron_offline_snapshot_hour: "%{hiera('aem_orchestrator::cron_offline_snapshot_hour')}"
-config_scheduled_jobs::cron_offline_snapshot_minute: "%{hiera('aem_orchestrator::cron_offline_snapshot_minute')}"
-config_scheduled_jobs::cron_offline_snapshot_weekday: "%{hiera('aem_orchestrator::cron_offline_snapshot_weekday')}"
+scheduled_jobs::offline_compaction_snapshot_enable: "%{alias('aem_orchestrator::scheduled_jobs::enable::offline_compaction_snapshot')}"
+scheduled_jobs::offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::scheduled_jobs::weekday::offline_compaction_snapshot')}"
+scheduled_jobs::offline_compaction_snapshot_hour: "%{hiera('aem_orchestrator::scheduled_jobs::hour::offline_compaction_snapshot')}"
+scheduled_jobs::offline_compaction_snapshot_minute: "%{hiera('aem_orchestrator::scheduled_jobs::minute::offline_compaction_snapshot')}"
+scheduled_jobs::offline_snapshot_enable: "%{alias('aem_orchestrator::scheduled_jobs::enable::offline_snapshot')}"
+scheduled_jobs::offline_snapshot_weekday: "%{hiera('aem_orchestrator::scheduled_jobs::weekday::offline_snapshot')}"
+scheduled_jobs::offline_snapshot_hour: "%{hiera('aem_orchestrator::scheduled_jobs::hour::offline_snapshot')}"
+scheduled_jobs::offline_snapshot_minute: "%{hiera('aem_orchestrator::scheduled_jobs::minute::offline_snapshot')}"
 
 aem_orchestrator::jarfile_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-orchestrator-%{hiera('orchestrator::aem_orchestrator_version')}.jar"
 aem_orchestrator::manage_installdir: true

--- a/data/orchestrator.yaml
+++ b/data/orchestrator.yaml
@@ -1,5 +1,6 @@
 ---
 orchestrator::base_dir: "%{hiera('common::base_dir')}"
+orchestrator::tmp_dir: "%{hiera('common::tmp_dir')}"
 orchestrator::aem_orchestrator_version: 1.0.0
 
 scheduled_jobs::offline_compaction_snapshot_enable: "%{alias('aem_orchestrator::scheduled_jobs::enable::offline_compaction_snapshot')}"

--- a/data/orchestrator.yaml
+++ b/data/orchestrator.yaml
@@ -2,14 +2,14 @@
 orchestrator::base_dir: "%{hiera('common::base_dir')}"
 orchestrator::aem_orchestrator_version: 1.0.0
 
-config_scheduled_jobs::enable_offline_compaction_snapshot_cron: "%{hiera('aem_orchestrator::enable_offline_compaction_snapshot_cron')}"
-config_scheduled_jobs::enable_offline_snapshot_cron: "%{hiera('aem_orchestrator::enable_offline_snapshot_cron')}"
-config_scheduled_jobs::offline_compaction_snapshot_hour: "%{hiera('aem_orchestrator::offline_compaction_snapshot_hour')}"
-config_scheduled_jobs::offline_compaction_snapshot_minute: "%{hiera('aem_orchestrator::offline_compaction_snapshot_minute')}"
-config_scheduled_jobs::offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::offline_compaction_snapshot_weekday')}"
-config_scheduled_jobs::offline_snapshot_hour: "%{hiera('aem_orchestrator::offline_snapshot_hour')}"
-config_scheduled_jobs::offline_snapshot_minute: "%{hiera('aem_orchestrator::offline_snapshot_minute')}"
-config_scheduled_jobs::offline_snapshot_weekday: "%{hiera('aem_orchestrator::offline_snapshot_weekday')}"
+config_scheduled_jobs::cron_offline_compaction_snapshot_enable: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_enable')}"
+config_scheduled_jobs::cron_offline_snapshot_enable: "%{hiera('aem_orchestrator::cron_offline_snapshot_enable')}"
+config_scheduled_jobs::cron_offline_compaction_snapshot_hour: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_hour')}"
+config_scheduled_jobs::cron_offline_compaction_snapshot_minute: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_minute')}"
+config_scheduled_jobs::cron_offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::cron_offline_compaction_snapshot_weekday')}"
+config_scheduled_jobs::cron_offline_snapshot_hour: "%{hiera('aem_orchestrator::cron_offline_snapshot_hour')}"
+config_scheduled_jobs::cron_offline_snapshot_minute: "%{hiera('aem_orchestrator::cron_offline_snapshot_minute')}"
+config_scheduled_jobs::cron_offline_snapshot_weekday: "%{hiera('aem_orchestrator::cron_offline_snapshot_weekday')}"
 
 aem_orchestrator::jarfile_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-orchestrator-%{hiera('orchestrator::aem_orchestrator_version')}.jar"
 aem_orchestrator::manage_installdir: true

--- a/data/orchestrator.yaml
+++ b/data/orchestrator.yaml
@@ -2,6 +2,15 @@
 orchestrator::base_dir: "%{hiera('common::base_dir')}"
 orchestrator::aem_orchestrator_version: 1.0.0
 
+config_scheduled_jobs::enable_offline_compaction_snapshot_cron: "%{hiera('aem_orchestrator::enable_offline_compaction_snapshot_cron')}"
+config_scheduled_jobs::enable_offline_snapshot_cron: "%{hiera('aem_orchestrator::enable_offline_snapshot_cron')}"
+config_scheduled_jobs::offline_compaction_snapshot_hour: "%{hiera('aem_orchestrator::offline_compaction_snapshot_hour')}"
+config_scheduled_jobs::offline_compaction_snapshot_minute: "%{hiera('aem_orchestrator::offline_compaction_snapshot_minute')}"
+config_scheduled_jobs::offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::offline_compaction_snapshot_weekday')}"
+config_scheduled_jobs::offline_snapshot_hour: "%{hiera('aem_orchestrator::offline_snapshot_hour')}"
+config_scheduled_jobs::offline_snapshot_minute: "%{hiera('aem_orchestrator::offline_snapshot_minute')}"
+config_scheduled_jobs::offline_snapshot_weekday: "%{hiera('aem_orchestrator::offline_snapshot_weekday')}"
+
 aem_orchestrator::jarfile_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-orchestrator-%{hiera('orchestrator::aem_orchestrator_version')}.jar"
 aem_orchestrator::manage_installdir: true
 aem_orchestrator::application_properties::aws_cloudformation_stack_name_messaging: "%{::stack_prefix}-aem-messaging-stack"

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -8,6 +8,15 @@ publish::aem_repo_devices:
 
 publish::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
+config_scheduled_jobs::cron_export_enable: "%{hiera('publish::cron_export_enable')}"
+config_scheduled_jobs::cron_export_hour: "%{hiera('publish::cron_export_hour')}"
+config_scheduled_jobs::cron_export_minute: "%{hiera('publish::cron_export_minute')}"
+config_scheduled_jobs::cron_export_weekday: "%{hiera('publish::cron_export_weekday')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('publish::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('publish::cron_live_snapshot_hour')}"
+config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('publish::cron_live_snapshot_minute')}"
+config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('publish::cron_live_snapshot_weekday')}"
+
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: publish
     aem_id: "%{hiera('publish::aem_id')}"
@@ -56,10 +65,12 @@ aem_curator::config_publish::enable_deploy_flag: false
 aem_curator::config_publish::login_ready_max_tries: 60
 aem_curator::config_publish::login_ready_base_sleep_seconds: 5
 aem_curator::config_publish::login_ready_max_sleep_seconds: 5
-aem_curator::config_publish::enable_offline_compaction_cron: false
-aem_curator::config_publish::enable_daily_export_cron: false
-aem_curator::config_publish::enable_hourly_live_snapshot_cron: false
 aem_curator::config_publish::enable_crxde: false
 aem_curator::config_publish::enable_default_passwords: false
 aem_curator::config_publish::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_publish::aem_password_reset_version')}.zip"
 aem_curator::config_publish::aem_password_reset_version: '1.0.2'
+
+aem_curator::config_aem_cronjobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
+aem_curator::config_aem_cronjobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -10,14 +10,14 @@ publish::volume_type: gp2
 
 publish::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
-config_scheduled_jobs::cron_export_enable: "%{alias('publish::cron_export_enable')}"
-config_scheduled_jobs::cron_export_hour: "%{hiera('publish::cron_export_hour')}"
-config_scheduled_jobs::cron_export_minute: "%{hiera('publish::cron_export_minute')}"
-config_scheduled_jobs::cron_export_weekday: "%{hiera('publish::cron_export_weekday')}"
-config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('publish::cron_live_snapshot_enable')}"
-config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('publish::cron_live_snapshot_hour')}"
-config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('publish::cron_live_snapshot_minute')}"
-config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('publish::cron_live_snapshot_weekday')}"
+scheduled_jobs::export_enable: "%{alias('publish::scheduled_jobs::enable::export')}"
+scheduled_jobs::export_weekday: "%{hiera('publish::scheduled_jobs::weekday::export')}"
+scheduled_jobs::export_hour: "%{hiera('publish::scheduled_jobs::hour::export')}"
+scheduled_jobs::export_minute: "%{hiera('publish::scheduled_jobs::minute::export')}"
+scheduled_jobs::live_snapshot_enable: "%{alias('publish::scheduled_jobs::enable::live_snapshot')}"
+scheduled_jobs::live_snapshot_weekday: "%{hiera('publish::scheduled_jobs::weekday::live_snapshot')}"
+scheduled_jobs::live_snapshot_hour: "%{hiera('publish::scheduled_jobs::hour::live_snapshot')}"
+scheduled_jobs::live_snapshot_minute: "%{hiera('publish::scheduled_jobs::minute::live_snapshot')}"
 
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: publish
@@ -71,7 +71,7 @@ aem_curator::config_publish::enable_default_passwords: false
 aem_curator::config_publish::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_publish::aem_password_reset_version')}.zip"
 aem_curator::config_publish::aem_password_reset_version: '1.0.2'
 
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{alias('publish::cron_offline_compaction_enable')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('publish::scheduled_jobs::aem::enable::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('publish::scheduled_jobs::aem::weekday::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_hour: "%{hiera('publish::scheduled_jobs::aem::hour::offline_compaction')}"
+aem_curator::config_aem_scheduled_jobs::offline_compaction_minute: "%{hiera('publish::scheduled_jobs::aem::minute::offline_compaction')}"

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -70,7 +70,7 @@ aem_curator::config_publish::enable_default_passwords: false
 aem_curator::config_publish::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_publish::aem_password_reset_version')}.zip"
 aem_curator::config_publish::aem_password_reset_version: '1.0.2'
 
-aem_curator::config_aem_cronjobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
-aem_curator::config_aem_cronjobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -10,11 +10,11 @@ publish::volume_type: gp2
 
 publish::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 
-config_scheduled_jobs::cron_export_enable: "%{hiera('publish::cron_export_enable')}"
+config_scheduled_jobs::cron_export_enable: "%{alias('publish::cron_export_enable')}"
 config_scheduled_jobs::cron_export_hour: "%{hiera('publish::cron_export_hour')}"
 config_scheduled_jobs::cron_export_minute: "%{hiera('publish::cron_export_minute')}"
 config_scheduled_jobs::cron_export_weekday: "%{hiera('publish::cron_export_weekday')}"
-config_scheduled_jobs::cron_live_snapshot_enable: "%{hiera('publish::cron_live_snapshot_enable')}"
+config_scheduled_jobs::cron_live_snapshot_enable: "%{alias('publish::cron_live_snapshot_enable')}"
 config_scheduled_jobs::cron_live_snapshot_hour: "%{hiera('publish::cron_live_snapshot_hour')}"
 config_scheduled_jobs::cron_live_snapshot_minute: "%{hiera('publish::cron_live_snapshot_minute')}"
 config_scheduled_jobs::cron_live_snapshot_weekday: "%{hiera('publish::cron_live_snapshot_weekday')}"
@@ -71,7 +71,7 @@ aem_curator::config_publish::enable_default_passwords: false
 aem_curator::config_publish::aem_password_reset_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-password-reset-content-%{hiera('aem_curator::config_publish::aem_password_reset_version')}.zip"
 aem_curator::config_publish::aem_password_reset_version: '1.0.2'
 
-aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{hiera('publish::cron_offline_compaction_enable')}"
+aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_enable: "%{alias('publish::cron_offline_compaction_enable')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_day: "%{hiera('publish::cron_offline_compaction_day')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_hour: "%{hiera('publish::cron_offline_compaction_hour')}"
 aem_curator::config_aem_scheduled_jobs::cron_offline_compaction_minute: "%{hiera('publish::cron_offline_compaction_minute')}"

--- a/manifests/author-primary.pp
+++ b/manifests/author-primary.pp
@@ -21,7 +21,7 @@ class author_primary (
     component       => $component,
     collectd_prefix => "${stack_prefix}-${component}",
     ec2_id          => $ec2_id
-  } -> class { 'aem_curator::config_aem_cronjobs':
+  } -> class { 'aem_curator::config_aem_scheduled_jobs':
   }
 
   ##############################################################################

--- a/manifests/author-primary.pp
+++ b/manifests/author-primary.pp
@@ -6,14 +6,10 @@ class author_primary (
   $base_dir,
   $aem_repo_devices,
   $aem_password_retrieval_command,
-  $enable_daily_export_cron,
-  $enable_hourly_live_snapshot_cron,
-  $component          = $::component,
-  $stack_prefix       = $::stack_prefix,
-  $env_path           = $::cron_env_path,
-  $aem_tools_env_path = '$PATH:/opt/puppetlabs/puppet/bin',
-  $https_proxy        = $::cron_https_proxy,
-  $ec2_id             = $::ec2_metadata['instance-id'],
+  $component                  = $::component,
+  $stack_prefix               = $::stack_prefix,
+  $aem_tools_env_path         = '$PATH:/opt/puppetlabs/puppet/bin',
+  $ec2_id                     = $::ec2_metadata['instance-id'],
 ) {
 
   class { 'aem_curator::config_aem_tools':
@@ -24,7 +20,8 @@ class author_primary (
   } -> class { 'aem_curator::config_collectd':
     component       => $component,
     collectd_prefix => "${stack_prefix}-${component}",
-    ec2_id          => "${ec2_id}"
+    ec2_id          => $ec2_id
+  } -> class { 'aem_curator::config_aem_cronjobs':
   }
 
   ##############################################################################
@@ -61,17 +58,6 @@ class author_primary (
     ),
   }
 
-  if $enable_daily_export_cron {
-    cron { 'daily-export-backups':
-      command     => "${base_dir}/aem-tools/export-backups.sh export-backups-descriptor.json >>/var/log/export-backups.log 2>&1",
-      user        => 'root',
-      hour        => 2,
-      minute      => 0,
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-      require     => File["${base_dir}/aem-tools/export-backups.sh"],
-    }
-    }
-
   ##############################################################################
   # Live snapshot backup
   ##############################################################################
@@ -91,16 +77,6 @@ class author_primary (
         'stack_prefix'       => $stack_prefix,
       }
     ),
-  }
-
-  if $enable_hourly_live_snapshot_cron {
-    cron { 'hourly-live-snapshot-backup':
-      command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
-      user        => 'root',
-      hour        => '*',
-      minute      => 0,
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-    }
   }
 
   ##############################################################################
@@ -123,6 +99,7 @@ class author_primary (
       }
     ),
   }
+
 }
 
 include author_primary

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -10,15 +10,11 @@ class author_publish_dispatcher (
   $publish_protocol,
   $publish_port,
   $aem_password_retrieval_command,
-  $enable_daily_export_cron,
   $enable_deploy_on_init,
-  $enable_hourly_live_snapshot_cron,
   $aem_repo_devices,
   $component             = $::component,
   $stack_prefix          = $::stack_prefix,
-  $env_path              = $::cron_env_path,
   $aem_tools_env_path    = '$PATH:/opt/puppetlabs/puppet/bin',
-  $https_proxy           = $::cron_https_proxy,
   $aem_id_author_primary = 'author-primary',
   $ec2_id                = $::ec2_metadata['instance-id'],
 ) {
@@ -59,7 +55,8 @@ class author_publish_dispatcher (
   } -> class { 'aem_curator::config_collectd':
     component       => $component,
     collectd_prefix => "${stack_prefix}-${component}",
-    ec2_id          => "${ec2_id}"
+    ec2_id          => $ec2_id
+  } -> class { 'aem_curator::config_aem_cronjobs':
   }
 
   ##############################################################################
@@ -96,17 +93,6 @@ class author_publish_dispatcher (
     ),
   }
 
-  if $enable_daily_export_cron {
-    cron { 'daily-export-backups':
-      command     => "${base_dir}/aem-tools/export-backups.sh export-backups-descriptor.json >>/var/log/export-backups.log 2>&1",
-      user        => 'root',
-      hour        => 2,
-      minute      => 0,
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-      require     => File["${base_dir}/aem-tools/export-backups.sh"],
-    }
-    }
-
   ##############################################################################
   # Live snapshot backup
   ##############################################################################
@@ -126,16 +112,6 @@ class author_publish_dispatcher (
         'stack_prefix'       => $stack_prefix,
       }
     ),
-  }
-
-  if $enable_hourly_live_snapshot_cron {
-    cron { 'hourly-live-snapshot-backup':
-      command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
-      user        => 'root',
-      hour        => '*',
-      minute      => 0,
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-    }
   }
 
   ##############################################################################
@@ -177,7 +153,7 @@ class deploy_on_init (
       onlyif      => "test `aws s3 ls s3://${::data_bucket_name}/${::stack_prefix}/deploy-artifacts-descriptor.json | wc -l` -eq 1",
     }
   }
-
+  
 }
 
 include author_publish_dispatcher

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -153,7 +153,7 @@ class deploy_on_init (
       onlyif      => "test `aws s3 ls s3://${::data_bucket_name}/${::stack_prefix}/deploy-artifacts-descriptor.json | wc -l` -eq 1",
     }
   }
-  
+
 }
 
 include author_publish_dispatcher

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -56,7 +56,7 @@ class author_publish_dispatcher (
     component       => $component,
     collectd_prefix => "${stack_prefix}-${component}",
     ec2_id          => $ec2_id
-  } -> class { 'aem_curator::config_aem_cronjobs':
+  } -> class { 'aem_curator::config_aem_scheduled_jobs':
   }
 
   ##############################################################################

--- a/manifests/author-standby.pp
+++ b/manifests/author-standby.pp
@@ -5,14 +5,11 @@ File {
 class author_standby (
   $base_dir,
   $aem_repo_devices,
-  $enable_hourly_live_snapshot_cron,
-  $author_primary_host = $::authorprimaryhost,
-  $component           = $::component,
-  $stack_prefix        = $::stack_prefix,
-  $env_path            = $::cron_env_path,
-  $aem_tools_env_path  = '$PATH:/opt/puppetlabs/puppet/bin',
-  $https_proxy         = $::cron_https_proxy,
-  $ec2_id              = $::ec2_metadata['instance-id'],
+  $author_primary_host        = $::authorprimaryhost,
+  $component                  = $::component,
+  $stack_prefix               = $::stack_prefix,
+  $aem_tools_env_path         = '$PATH:/opt/puppetlabs/puppet/bin',
+  $ec2_id                     = $::ec2_metadata['instance-id'],
 ) {
 
   class { 'aem_curator::config_aem_tools':
@@ -46,16 +43,6 @@ class author_standby (
         'stack_prefix'       => $stack_prefix,
       }
     ),
-  }
-
-  if $enable_hourly_live_snapshot_cron {
-    cron { 'hourly-live-snapshot-backup':
-      command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
-      user        => 'root',
-      hour        => '*',
-      minute      => 0,
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-    }
   }
 
   ##############################################################################
@@ -95,6 +82,7 @@ class author_standby (
       }
     ),
   }
+
 }
 
 include author_standby

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -5,12 +5,7 @@ File {
 class orchestrator (
   $base_dir,
   $aem_tools_env_path                        = '$PATH:/opt/puppetlabs/puppet/bin',
-  $offline_snapshot_hour                     = 1,
-  $offline_snapshot_minute                   = 15,
-  $enable_weekly_offline_compaction_snapshot = true,
-  $stack_prefix                              = $::stack_prefix,
-  $env_path                                  = $::cron_env_path,
-  $https_proxy                               = $::cron_https_proxy,
+  $stack_prefix                              = $::stack_prefix
 ) {
 
   Archive {
@@ -37,35 +32,6 @@ class orchestrator (
     group   => 'root',
   }
 
-  # If weekly stack offline compaction snapshot is enabled, nightly stack offline
-  # snapshot only runs from Tuesday to Sunday, leaving Monday for _both_ stack offline
-  # snapshot and compaction (configured further down).
-  # If it's not enabled, nightly stack offline snapshot runs every day of the week.
-  if $enable_weekly_offline_compaction_snapshot {
-    # Tuesday to Sunday
-    cron { 'nightly-stack-offline-snapshot':
-      command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
-      user        => 'root',
-      hour        => $offline_snapshot_hour,
-      minute      => $offline_snapshot_minute,
-      weekday     => '2-7',
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-      require     => File["${base_dir}/aem-tools/stack-offline-snapshot.sh"],
-    }
-  }
-  else {
-    # Monday to Sunday
-    cron { 'nightly-stack-offline-snapshot':
-      command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
-      user        => 'root',
-      hour        => $offline_snapshot_hour,
-      minute      => $offline_snapshot_minute,
-      weekday     => '1-7',
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-      require     => File["${base_dir}/aem-tools/stack-offline-snapshot.sh"],
-    }
-  }
-
   ##############################################################################
   # Stack-level offline snapshot with compaction
   ##############################################################################
@@ -82,21 +48,6 @@ class orchestrator (
     mode    => '0775',
     owner   => 'root',
     group   => 'root',
-  }
-
-  # If weekly stack offline compaction snapshot is enabled, then set both stack
-  # offline snapshot and compaction to run one day a week.
-  if $enable_weekly_offline_compaction_snapshot {
-    # Monday only
-    cron { 'weekly-stack-offline-compaction-snapshot':
-      command     => "cd ${base_dir}/aem-tools && ./stack-offline-compaction-snapshot.sh >/var/log/stack-offline-compaction-snapshot.log 2>&1",
-      user        => 'root',
-      hour        => $offline_snapshot_hour,
-      minute      => $offline_snapshot_minute,
-      weekday     => 1,
-      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
-      require     => File["${base_dir}/aem-tools/stack-offline-compaction-snapshot.sh"],
-    }
   }
 
   ##############################################################################

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -4,8 +4,11 @@ File {
 
 class orchestrator (
   $base_dir,
-  $aem_tools_env_path                        = '$PATH:/opt/puppetlabs/puppet/bin',
-  $stack_prefix                              = $::stack_prefix
+  $tmp_dir,
+  $aem_tools_env_path = '$PATH:/opt/puppetlabs/puppet/bin',
+  $data_bucket_name   = $::data_bucket_name,
+  $stack_prefix       = $::stack_prefix
+
 ) {
 
   Archive {
@@ -45,6 +48,26 @@ class orchestrator (
   } -> file { "${base_dir}/aem-tools/stack-offline-compaction-snapshot.sh":
     ensure  => present,
     content => epp("${base_dir}/aem-aws-stack-provisioner/templates/aem-tools/stack-offline-compaction-snapshot.sh.epp", { 'sns_topic_arn' => "${::stack_manager_sns_topic_arn}",}),
+    mode    => '0775',
+    owner   => 'root',
+    group   => 'root',
+  }
+
+  ##############################################################################
+  # Schedule jobs for offline snapshot & offline compaction snapshot
+  ##############################################################################
+
+  file { "${base_dir}/aem-tools/schedule-offline-snapshots.sh":
+    ensure  => present,
+    content => epp("${base_dir}/aem-aws-stack-provisioner/templates/aem-tools/schedule-offline-snapshots.sh.epp",
+    {
+      'aem_tools_env_path' => $aem_tools_env_path,
+      'base_dir'           => $base_dir,
+      'data_bucket_name'   => $data_bucket_name,
+      'stack_prefix'       => $stack_prefix,
+      'tmp_dir'            => $tmp_dir
+      }
+    ),
     mode    => '0775',
     owner   => 'root',
     group   => 'root',

--- a/manifests/pre-common.pp
+++ b/manifests/pre-common.pp
@@ -164,7 +164,7 @@ class common (
   # initialisation.
   archive { "${tmp_dir}/${credentials_file}":
     ensure => present,
-    source => "s3://${data_bucket_name}/${stack_prefix}/${credentials_file}",
+    source => "s3://${data_bucket_name}/${stack_prefix}/${credentials_file}"
   }
 }
 

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -25,7 +25,7 @@ class publish (
     component       => $component,
     collectd_prefix => "${stack_prefix}-${component}",
     ec2_id          => $ec2_id
-  } -> class { 'aem_curator::config_aem_cronjobs':
+  } -> class { 'aem_curator::config_aem_scheduled_jobs':
   }
 
   ##############################################################################

--- a/manifests/scheduled-job.pp
+++ b/manifests/scheduled-job.pp
@@ -1,0 +1,104 @@
+File {
+  backup => false,
+}
+
+class config_scheduled_jobs (
+  $base_dir,
+  $env_path                                  = $::cron_env_path,
+  $https_proxy                               = $::cron_https_proxy,
+  $enable_offline_compaction_snapshot_cron   = undef,
+  $enable_offline_snapshot_cron              = undef,
+  $cron_export_enable                        = undef,
+  $cron_live_snapshot_enable                 = undef,
+  $cron_export_hour                          = '2',
+  $cron_export_minute                        = '0',
+  $cron_export_weekday                       = '0-7',
+  $cron_live_snapshot_hour                   = '*',
+  $cron_live_snapshot_minute                 = '0',
+  $cron_live_snapshot_weekday                = '0-7',
+  $offline_compaction_snapshot_hour          = '1',
+  $offline_compaction_snapshot_minute        = '15',
+  $offline_compaction_snapshot_weekday       = '1',
+  $offline_snapshot_hour                     = '1',
+  $offline_snapshot_minute                   = '15',
+  $offline_snapshot_weekday                  = '2-7',
+) {
+
+  if $enable_offline_snapshot_cron == 'true' {
+    cron { 'stack-offline-snapshot':
+      ensure      => present,
+      command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
+      user        => 'root',
+      hour        => $offline_snapshot_hour,
+      minute      => $offline_snapshot_minute,
+      weekday     => $offline_snapshot_weekday,
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
+    }
+  } else {
+    cron { 'stack-offline-snapshot':
+      ensure      => absent,
+      command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
+      user        => 'root',
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""]
+    }
+  }
+
+  if $enable_offline_compaction_snapshot_cron == 'true' {
+    cron { 'stack-offline-compaction-snapshot':
+      ensure      => present,
+      command     => "cd ${base_dir}/aem-tools && ./stack-offline-compaction-snapshot.sh >/var/log/stack-offline-compaction-snapshot.log 2>&1",
+      user        => 'root',
+      hour        => $offline_compaction_snapshot_hour,
+      minute      => $offline_compaction_snapshot_minute,
+      weekday     => $offline_compaction_snapshot_weekday,
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
+    }
+  } else {
+    cron { 'stack-offline-compaction-snapshot':
+      ensure      => absent,
+      command     => "cd ${base_dir}/aem-tools && ./stack-offline-compaction-snapshot.sh >/var/log/stack-offline-compaction-snapshot.log 2>&1",
+      user        => 'root',
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""]
+    }
+  }
+
+  if $cron_live_snapshot_enable == 'true' {
+    cron { 'live-snapshot-backup':
+      ensure      => present,
+      command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
+      user        => 'root',
+      hour        => $cron_live_snapshot_hour,
+      minute      => $cron_live_snapshot_minute,
+      weekday     => $cron_live_snapshot_weekday,
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
+    }
+  } else {
+    cron { 'live-snapshot-backup':
+    ensure      => absent,
+    command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
+    user        => 'root',
+    environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""]
+    }
+  }
+
+  if $cron_export_enable == 'true' {
+    cron { 'export-backups':
+      ensure      => present,
+      command     => "${base_dir}/aem-tools/export-backups.sh export-backups-descriptor.json >>/var/log/export-backups.log 2>&1",
+      user        => 'root',
+      hour        => $cron_export_hour,
+      minute      => $cron_export_minute,
+      weekday     => $cron_export_weekday,
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
+    }
+  } else {
+    cron { 'export-backups':
+      ensure      => absent,
+      command     => "${base_dir}/aem-tools/export-backups.sh export-backups-descriptor.json >>/var/log/export-backups.log 2>&1",
+      user        => 'root',
+      environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""]
+    }
+  }
+}
+
+include config_scheduled_jobs

--- a/manifests/scheduled-job.pp
+++ b/manifests/scheduled-job.pp
@@ -2,36 +2,36 @@ File {
   backup => false,
 }
 
-class config_scheduled_jobs (
+class scheduled_jobs (
   $base_dir,
-  $env_path                                       = $::cron_env_path,
-  $https_proxy                                    = $::cron_https_proxy,
-  $cron_offline_compaction_snapshot_enable        = false,
-  $cron_offline_snapshot_enable                   = false,
-  $cron_export_enable                             = false,
-  $cron_live_snapshot_enable                      = false,
-  $cron_export_hour                               = '2',
-  $cron_export_minute                             = '0',
-  $cron_export_weekday                            = '0-7',
-  $cron_live_snapshot_hour                        = '*',
-  $cron_live_snapshot_minute                      = '0',
-  $cron_live_snapshot_weekday                     = '0-7',
-  $cron_offline_compaction_snapshot_hour          = '1',
-  $cron_offline_compaction_snapshot_minute        = '15',
-  $cron_offline_compaction_snapshot_weekday       = '1',
-  $cron_offline_snapshot_hour                     = '1',
-  $cron_offline_snapshot_minute                   = '15',
-  $cron_offline_snapshot_weekday                  = '2-7',
+  $env_path                            = $::cron_env_path,
+  $https_proxy                         = $::cron_https_proxy,
+  $export_enable                       = false,
+  $live_snapshot_enable                = false,
+  $offline_compaction_snapshot_enable  = false,
+  $offline_snapshot_enable             = false,
+  $export_hour                         = '2',
+  $export_minute                       = '0',
+  $export_weekday                      = '0-7',
+  $live_snapshot_hour                  = '*',
+  $live_snapshot_minute                = '0',
+  $live_snapshot_weekday               = '0-7',
+  $offline_compaction_snapshot_hour    = '1',
+  $offline_compaction_snapshot_minute  = '15',
+  $offline_compaction_snapshot_weekday = '1',
+  $offline_snapshot_hour               = '1',
+  $offline_snapshot_minute             = '15',
+  $offline_snapshot_weekday            = '2-7',
 ) {
 
-  if $cron_offline_snapshot_enable == true {
+  if $offline_snapshot_enable == true {
     cron { 'stack-offline-snapshot':
       ensure      => present,
       command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
       user        => 'root',
-      hour        => $cron_offline_snapshot_hour,
-      minute      => $cron_offline_snapshot_minute,
-      weekday     => $cron_offline_snapshot_weekday,
+      hour        => $offline_snapshot_hour,
+      minute      => $offline_snapshot_minute,
+      weekday     => $offline_snapshot_weekday,
       environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
     }
   } else {
@@ -43,14 +43,14 @@ class config_scheduled_jobs (
     }
   }
 
-  if $cron_offline_compaction_snapshot_enable == true {
+  if $offline_compaction_snapshot_enable == true {
     cron { 'stack-offline-compaction-snapshot':
       ensure      => present,
       command     => "cd ${base_dir}/aem-tools && ./stack-offline-compaction-snapshot.sh >/var/log/stack-offline-compaction-snapshot.log 2>&1",
       user        => 'root',
-      hour        => $cron_offline_compaction_snapshot_hour,
-      minute      => $cron_offline_compaction_snapshot_minute,
-      weekday     => $cron_offline_compaction_snapshot_weekday,
+      hour        => $offline_compaction_snapshot_hour,
+      minute      => $offline_compaction_snapshot_minute,
+      weekday     => $offline_compaction_snapshot_weekday,
       environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
     }
   } else {
@@ -62,14 +62,14 @@ class config_scheduled_jobs (
     }
   }
 
-  if $cron_live_snapshot_enable == true {
+  if $live_snapshot_enable == true {
     cron { 'live-snapshot-backup':
       ensure      => present,
       command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
       user        => 'root',
-      hour        => $cron_live_snapshot_hour,
-      minute      => $cron_live_snapshot_minute,
-      weekday     => $cron_live_snapshot_weekday,
+      hour        => $live_snapshot_hour,
+      minute      => $live_snapshot_minute,
+      weekday     => $live_snapshot_weekday,
       environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
     }
   } else {
@@ -81,14 +81,14 @@ class config_scheduled_jobs (
     }
   }
 
-  if $cron_export_enable == true {
+  if $export_enable == true {
     cron { 'export-backups':
       ensure      => present,
       command     => "${base_dir}/aem-tools/export-backups.sh export-backups-descriptor.json >>/var/log/export-backups.log 2>&1",
       user        => 'root',
-      hour        => $cron_export_hour,
-      minute      => $cron_export_minute,
-      weekday     => $cron_export_weekday,
+      hour        => $export_hour,
+      minute      => $export_minute,
+      weekday     => $export_weekday,
       environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
     }
   } else {
@@ -101,4 +101,4 @@ class config_scheduled_jobs (
   }
 }
 
-include config_scheduled_jobs
+include scheduled_jobs

--- a/manifests/scheduled-job.pp
+++ b/manifests/scheduled-job.pp
@@ -4,18 +4,18 @@ File {
 
 class config_scheduled_jobs (
   $base_dir,
-  $env_path                                  = $::cron_env_path,
-  $https_proxy                               = $::cron_https_proxy,
-  $cron_offline_compaction_snapshot_enable   = undef,
-  $cron_offline_snapshot_enable              = undef,
-  $cron_export_enable                        = undef,
-  $cron_live_snapshot_enable                 = undef,
-  $cron_export_hour                          = '2',
-  $cron_export_minute                        = '0',
-  $cron_export_weekday                       = '0-7',
-  $cron_live_snapshot_hour                   = '*',
-  $cron_live_snapshot_minute                 = '0',
-  $cron_live_snapshot_weekday                = '0-7',
+  $env_path                                       = $::cron_env_path,
+  $https_proxy                                    = $::cron_https_proxy,
+  $cron_offline_compaction_snapshot_enable        = false,
+  $cron_offline_snapshot_enable                   = false,
+  $cron_export_enable                             = false,
+  $cron_live_snapshot_enable                      = false,
+  $cron_export_hour                               = '2',
+  $cron_export_minute                             = '0',
+  $cron_export_weekday                            = '0-7',
+  $cron_live_snapshot_hour                        = '*',
+  $cron_live_snapshot_minute                      = '0',
+  $cron_live_snapshot_weekday                     = '0-7',
   $cron_offline_compaction_snapshot_hour          = '1',
   $cron_offline_compaction_snapshot_minute        = '15',
   $cron_offline_compaction_snapshot_weekday       = '1',
@@ -24,7 +24,7 @@ class config_scheduled_jobs (
   $cron_offline_snapshot_weekday                  = '2-7',
 ) {
 
-  if $cron_offline_snapshot_enable == 'true' {
+  if $cron_offline_snapshot_enable == true {
     cron { 'stack-offline-snapshot':
       ensure      => present,
       command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
@@ -43,7 +43,7 @@ class config_scheduled_jobs (
     }
   }
 
-  if $cron_offline_compaction_snapshot_enable == 'true' {
+  if $cron_offline_compaction_snapshot_enable == true {
     cron { 'stack-offline-compaction-snapshot':
       ensure      => present,
       command     => "cd ${base_dir}/aem-tools && ./stack-offline-compaction-snapshot.sh >/var/log/stack-offline-compaction-snapshot.log 2>&1",
@@ -62,7 +62,7 @@ class config_scheduled_jobs (
     }
   }
 
-  if $cron_live_snapshot_enable == 'true' {
+  if $cron_live_snapshot_enable == true {
     cron { 'live-snapshot-backup':
       ensure      => present,
       command     => "${base_dir}/aem-tools/live-snapshot-backup.sh >>/var/log/live-snapshot-backup.log 2>&1",
@@ -81,7 +81,7 @@ class config_scheduled_jobs (
     }
   }
 
-  if $cron_export_enable == 'true' {
+  if $cron_export_enable == true {
     cron { 'export-backups':
       ensure      => present,
       command     => "${base_dir}/aem-tools/export-backups.sh export-backups-descriptor.json >>/var/log/export-backups.log 2>&1",

--- a/manifests/scheduled-job.pp
+++ b/manifests/scheduled-job.pp
@@ -6,8 +6,8 @@ class config_scheduled_jobs (
   $base_dir,
   $env_path                                  = $::cron_env_path,
   $https_proxy                               = $::cron_https_proxy,
-  $enable_offline_compaction_snapshot_cron   = undef,
-  $enable_offline_snapshot_cron              = undef,
+  $cron_offline_compaction_snapshot_enable   = undef,
+  $cron_offline_snapshot_enable              = undef,
   $cron_export_enable                        = undef,
   $cron_live_snapshot_enable                 = undef,
   $cron_export_hour                          = '2',
@@ -16,22 +16,22 @@ class config_scheduled_jobs (
   $cron_live_snapshot_hour                   = '*',
   $cron_live_snapshot_minute                 = '0',
   $cron_live_snapshot_weekday                = '0-7',
-  $offline_compaction_snapshot_hour          = '1',
-  $offline_compaction_snapshot_minute        = '15',
-  $offline_compaction_snapshot_weekday       = '1',
-  $offline_snapshot_hour                     = '1',
-  $offline_snapshot_minute                   = '15',
-  $offline_snapshot_weekday                  = '2-7',
+  $cron_offline_compaction_snapshot_hour          = '1',
+  $cron_offline_compaction_snapshot_minute        = '15',
+  $cron_offline_compaction_snapshot_weekday       = '1',
+  $cron_offline_snapshot_hour                     = '1',
+  $cron_offline_snapshot_minute                   = '15',
+  $cron_offline_snapshot_weekday                  = '2-7',
 ) {
 
-  if $enable_offline_snapshot_cron == 'true' {
+  if $cron_offline_snapshot_enable == 'true' {
     cron { 'stack-offline-snapshot':
       ensure      => present,
       command     => "cd ${base_dir}/aem-tools && ./stack-offline-snapshot.sh >/var/log/stack-offline-snapshot.log 2>&1",
       user        => 'root',
-      hour        => $offline_snapshot_hour,
-      minute      => $offline_snapshot_minute,
-      weekday     => $offline_snapshot_weekday,
+      hour        => $cron_offline_snapshot_hour,
+      minute      => $cron_offline_snapshot_minute,
+      weekday     => $cron_offline_snapshot_weekday,
       environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
     }
   } else {
@@ -43,14 +43,14 @@ class config_scheduled_jobs (
     }
   }
 
-  if $enable_offline_compaction_snapshot_cron == 'true' {
+  if $cron_offline_compaction_snapshot_enable == 'true' {
     cron { 'stack-offline-compaction-snapshot':
       ensure      => present,
       command     => "cd ${base_dir}/aem-tools && ./stack-offline-compaction-snapshot.sh >/var/log/stack-offline-compaction-snapshot.log 2>&1",
       user        => 'root',
-      hour        => $offline_compaction_snapshot_hour,
-      minute      => $offline_compaction_snapshot_minute,
-      weekday     => $offline_compaction_snapshot_weekday,
+      hour        => $cron_offline_compaction_snapshot_hour,
+      minute      => $cron_offline_compaction_snapshot_minute,
+      weekday     => $cron_offline_compaction_snapshot_weekday,
       environment => ["PATH=${env_path}", "https_proxy=\"${https_proxy}\""],
     }
   } else {

--- a/templates/aem-tools/schedule-offline-snapshots.sh.epp
+++ b/templates/aem-tools/schedule-offline-snapshots.sh.epp
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -o nounset
+set -o errexit
+
+if [ "$#" -ne 2 ]; then
+  echo 'Usage: ./schedule-offline-snapshots.sh <all | offline_snapshot | offline_compaction_snapshot> <enable | disable>'
+  exit 1
+fi
+
+# translate exit code to follow convention
+translate_exit_code() {
+
+  exit_code="$1"
+  if [ "$exit_code" -eq 0 ]; then
+    exit_code=0
+  else
+    rm -rf "${tmp_dir:?}/*"
+    exit "$exit_code"
+  fi
+
+  return "$exit_code"
+}
+
+# translate puppet exit code to follow convention
+translate_puppet_exit_code() {
+
+  exit_code="$1"
+  if [ "$exit_code" -eq 0 ] || [ "$exit_code" -eq 2 ]; then
+    exit_code=0
+  else
+    rm -rf "${tmp_dir:?}/*"
+    exit "$exit_code"
+  fi
+
+  return "$exit_code"
+}
+
+PATH=<%= $aem_tools_env_path %>
+
+scheduled_job_name=$1
+state=$2
+
+tmp_dir=<%= $tmp_dir %>/schedule_offline_snapshot
+
+cd "<%= $base_dir %>/aem-aws-stack-provisioner/"
+
+###################################################
+# Case check to enable/disable all
+# or a specific offline snapshot
+###################################################
+case "$state" in
+  enable)
+    mkdir -p ${tmp_dir}
+    case "$scheduled_job_name" in
+      all)
+        sed -e '/^.*scheduled_jobs.*enable::offline.*$/s/False$/True/' \
+        < <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml \
+        >> ${tmp_dir}/local.yaml
+
+        translate_exit_code "$?"
+      ;;
+      offline_snapshot)
+        sed -e '/^.*scheduled_jobs.*enable::offline_snapshot.*$/s/False$/True/' \
+        < <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml \
+        >> ${tmp_dir}/local.yaml
+
+        translate_exit_code "$?"
+      ;;
+      offline_compaction_snapshot)
+        sed -e '/^.*scheduled_jobs.*enable::offline_compaction_snapshot.*$/s/False$/True/' \
+        < <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml \
+        >> ${tmp_dir}/local.yaml
+
+        translate_exit_code "$?"
+      ;;
+      *)
+        exit 1
+      ;;
+    esac
+    ;;
+  disable)
+    mkdir -p ${tmp_dir}
+    case "$scheduled_job_name" in
+      all)
+        sed -e '/^.*scheduled_jobs.*enable::offline.*$/s/True$/False/' \
+        < <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml \
+        >> ${tmp_dir}/local.yaml
+
+        translate_exit_code "$?"
+      ;;
+      offline_snapshot)
+        sed -e '/^.*scheduled_jobs.*enable::offline_snapshot.*$/s/True$/False/' \
+        < <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml \
+        >> ${tmp_dir}/local.yaml
+
+        translate_exit_code "$?"
+      ;;
+      offline_compaction_snapshot)
+
+        sed -e '/^.*scheduled_jobs.*enable::offline_compaction_snapshot.*$/s/True$/False/' \
+        < <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml \
+        >> ${tmp_dir}/local.yaml
+
+        translate_exit_code "$?"
+      ;;
+      *)
+        exit 1
+      ;;
+    esac
+  ;;
+  *)
+    exit 1
+  ;;
+esac
+
+aws s3 cp "${tmp_dir}/local.yaml" "s3://<%= $data_bucket_name %>/<%= $stack_prefix %>/data/local.yaml"
+translate_exit_code "$?"
+
+mv -f "${tmp_dir}/local.yaml" <%= $base_dir %>/aem-aws-stack-provisioner/data/local.yaml
+translate_exit_code "$?"
+
+cd "<%= $base_dir %>/aem-aws-stack-provisioner/"
+# Schedule job for offline-snapshot
+echo "Applying scheduled-job Puppet manifest for all components..."
+puppet apply \
+  --detailed-exitcodes \
+  --debug \
+  --modulepath modules \
+  --hiera_config conf/hiera.yaml \
+  manifests/scheduled-job.pp
+
+translate_puppet_exit_code "$?"
+
+rm -rf "${tmp_dir:?}/*"

--- a/templates/aem-tools/schedule-offline-snapshots.sh.epp
+++ b/templates/aem-tools/schedule-offline-snapshots.sh.epp
@@ -43,7 +43,7 @@ state=$2
 tmp_dir=<%= $tmp_dir %>/schedule_offline_snapshot
 
 cd "<%= $base_dir %>/aem-aws-stack-provisioner/"
-
+set +o errexit
 ###################################################
 # Case check to enable/disable all
 # or a specific offline snapshot

--- a/templates/aws-tools/promote-author-standby-to-primary.sh.epp
+++ b/templates/aws-tools/promote-author-standby-to-primary.sh.epp
@@ -9,6 +9,21 @@ if [ "$#" -ne 0 ]; then
   exit 1
 fi
 
+# translate puppet exit code to follow convention
+translate_exit_code() {
+
+  exit_code="$1"
+  if [ "$exit_code" -eq 0 ] || [ "$exit_code" -eq 2 ]; then
+    exit_code=0
+  else
+    exit "$exit_code"
+  fi
+
+  return "$exit_code"
+}
+
+set +o errexit
+
 data_bucket_name=$(facter data_bucket_name)
 stack_prefix=$(facter stack_prefix)
 component=author-primary
@@ -20,3 +35,14 @@ aws ec2 create-tags --tags Key=Name,Value="AEM Author - Primary - Promoted from 
 <%= $base_dir %>/aws-tools/set-facts.sh "${data_bucket_name}" "${stack_prefix}"
 
 <%= $base_dir %>/aem-tools/promote-author-standby-to-primary.sh
+
+cd <%= $base_dir %>/aem-aws-stack-provisioner/
+echo "Applying scheduled-job Puppet manifest for all components..."
+puppet apply \
+  --detailed-exitcodes \
+  --debug \
+  --modulepath modules \
+  --hiera_config conf/hiera.yaml \
+  manifests/scheduled-job.pp
+
+translate_exit_code "$?"


### PR DESCRIPTION
Added managing of AEM AWS regarded scheduled jobs.
    
    * Added new puppet manifest to configure all AEM AWS regarded scheduled jobs
    * Update data files
    * Scheduled jobs can be configured from AEM AWS Stack Builder level
    * Update promote author standby to primary script to set all scheduled job for author primary
