### PR TITLE
Add class in component manifests to update /etc/awslogs/awslogs.conf

### DIFF
--- a/manifests/author-dispatcher.pp
+++ b/manifests/author-dispatcher.pp
@@ -6,6 +6,7 @@ class author_dispatcher (
   $base_dir,
   $docroot_dir,
   $author_host        = $::authorhost,
+  $component          = $::component,
   $stack_prefix       = $::stack_prefix,
   $data_bucket_name   = $::data_bucket_name,
   $exec_path          = ['/bin', '/usr/local/bin', '/usr/bin'],
@@ -44,6 +45,29 @@ class author_dispatcher (
     mode   => '0775',
     owner  => 'root',
     group  => 'root',
+  }
+  ##############################################################################
+  # Update /etc/awslogs/awslogs.conf
+  # to contain stack_prefix and component name
+  ##############################################################################
+
+  class { 'update_awslogs': }
+}
+
+class update_awslogs (
+  $old_awslogs_content = file('/etc/awslogs/awslogs.conf'),
+) {
+  service { 'awslogs':
+    ensure => 'running',
+    enable => true
+  }
+  $mod_awslogs_content = regsubst($old_awslogs_content, '^log_group_name = ', "log_group_name = ${$stack_prefix}", 'G' )
+  $new_awslogs_content = regsubst($mod_awslogs_content, '^log_stream_name = ', "log_stream_name = ${$component}/", 'G' )
+  file { 'Update file /etc/awslogs/awslogs.conf':
+    ensure  => file,
+    content => $new_awslogs_content,
+    path    => '/etc/awslogs/awslogs.conf',
+    notify  => Service['awslogs'],
   }
 }
 

--- a/manifests/author-standby.pp
+++ b/manifests/author-standby.pp
@@ -82,7 +82,29 @@ class author_standby (
       }
     ),
   }
+  ##############################################################################
+  # Update /etc/awslogs/awslogs.conf
+  # to contain stack_prefix and component name
+  ##############################################################################
 
+  class { 'update_awslogs': }
+}
+
+class update_awslogs (
+  $old_awslogs_content = file('/etc/awslogs/awslogs.conf'),
+) {
+  service { 'awslogs':
+    ensure => 'running',
+    enable => true
+  }
+  $mod_awslogs_content = regsubst($old_awslogs_content, '^log_group_name = ', "log_group_name = ${$stack_prefix}", 'G' )
+  $new_awslogs_content = regsubst($mod_awslogs_content, '^log_stream_name = ', "log_stream_name = ${$component}/", 'G' )
+  file { 'Update file /etc/awslogs/awslogs.conf':
+    ensure  => file,
+    content => $new_awslogs_content,
+    path    => '/etc/awslogs/awslogs.conf',
+    notify  => Service['awslogs'],
+  }
 }
 
 include author_standby

--- a/manifests/chaos-monkey.pp
+++ b/manifests/chaos-monkey.pp
@@ -3,6 +3,8 @@ File {
 }
 
 class chaos_monkey (
+  $component              = $::component,
+  $stack_prefix           = $::stack_prefix,
   $orchestrator_asg       = $::orchestratorasg,
   $publish_asg            = $::publisherasg,
   $publish_dispatcher_asg = $::publisherdispatcherasg,
@@ -41,6 +43,29 @@ class chaos_monkey (
     max_terminations_per_day => '1.0',
   }
 
+  ##############################################################################
+  # Update /etc/awslogs/awslogs.conf
+  # to contain stack_prefix and component name
+  ##############################################################################
+
+  class { 'update_awslogs': }
+}
+
+class update_awslogs (
+  $old_awslogs_content = file('/etc/awslogs/awslogs.conf'),
+) {
+  service { 'awslogs':
+    ensure => 'running',
+    enable => true
+  }
+  $mod_awslogs_content = regsubst($old_awslogs_content, '^log_group_name = ', "log_group_name = ${$stack_prefix}", 'G' )
+  $new_awslogs_content = regsubst($mod_awslogs_content, '^log_stream_name = ', "log_stream_name = ${$component}/", 'G' )
+  file { 'Update file /etc/awslogs/awslogs.conf':
+    ensure  => file,
+    content => $new_awslogs_content,
+    path    => '/etc/awslogs/awslogs.conf',
+    notify  => Service['awslogs'],
+  }
 }
 
 include chaos_monkey

--- a/manifests/publish-dispatcher.pp
+++ b/manifests/publish-dispatcher.pp
@@ -8,6 +8,7 @@ class publish_dispatcher (
   $tmp_dir,
   $allowed_client             = $::publish_dispatcher_allowed_client,
   $publish_host               = $::publishhost,
+  $component                  = $::component,
   $stack_prefix               = $::stack_prefix,
   $data_bucket_name           = $::data_bucket_name,
   $env_path                   = $::cron_env_path,
@@ -75,6 +76,30 @@ class publish_dispatcher (
     mode   => '0775',
     owner  => 'root',
     group  => 'root',
+  }
+
+  ##############################################################################
+  # Update /etc/awslogs/awslogs.conf
+  # to contain stack_prefix and component name
+  ##############################################################################
+
+  class { 'update_awslogs': }
+}
+
+class update_awslogs (
+  $old_awslogs_content = file('/etc/awslogs/awslogs.conf'),
+) {
+  service { 'awslogs':
+    ensure => 'running',
+    enable => true
+  }
+  $mod_awslogs_content = regsubst($old_awslogs_content, '^log_group_name = ', "log_group_name = ${$stack_prefix}", 'G' )
+  $new_awslogs_content = regsubst($mod_awslogs_content, '^log_stream_name = ', "log_stream_name = ${$component}/", 'G' )
+  file { 'Update file /etc/awslogs/awslogs.conf':
+    ensure  => file,
+    content => $new_awslogs_content,
+    path    => '/etc/awslogs/awslogs.conf',
+    notify  => Service['awslogs'],
   }
 }
 

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -134,6 +134,29 @@ class publish (
     group  => 'root',
   }
 
+  ##############################################################################
+  # Update /etc/awslogs/awslogs.conf
+  # to contain stack_prefix and component name
+  ##############################################################################
+
+  class { 'update_awslogs': }
+}
+
+class update_awslogs (
+  $old_awslogs_content = file('/etc/awslogs/awslogs.conf'),
+) {
+  service { 'awslogs':
+    ensure => 'running',
+    enable => true
+  }
+  $mod_awslogs_content = regsubst($old_awslogs_content, '^log_group_name = ', "log_group_name = ${$stack_prefix}", 'G' )
+  $new_awslogs_content = regsubst($mod_awslogs_content, '^log_stream_name = ', "log_stream_name = ${$component}/", 'G' )
+  file { 'Update file /etc/awslogs/awslogs.conf':
+    ensure  => file,
+    content => $new_awslogs_content,
+    path    => '/etc/awslogs/awslogs.conf',
+    notify  => Service['awslogs'],
+  }
 }
 
 include publish


### PR DESCRIPTION
Add class in component manifests to update /etc/awslogs/awslogs.conf containing stack-prefix and component name in AWS log_group_name & log_stream_name