### PR TITLE
Enhancement 3/upgrade hiera config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-### 2.5.1
-* Update hiera configuration file to version 5
-
 ### 2.5.0
 * Fix cron scheduled execution of offline snapshot by specifying message full path
 * Enable publish launch configuration default to be set to the live or offline snapshot
+* Upgrade Hiera configuration file to version 5
 
 ### 2.4.18
 * Replace global SNS topic ARN with Stack Manager stack name class parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.5.1
+* Update hiera configuration file to version 5
+
 ### 2.5.0
 * Fix cron scheduled execution of offline snapshot by specifying message full path
 * Enable publish launch configuration default to be set to the live or offline snapshot

--- a/conf/hiera.yaml
+++ b/conf/hiera.yaml
@@ -1,12 +1,14 @@
 ---
-:backends: yaml
-:yaml:
-  :datadir: /opt/shinesolutions/aem-aws-stack-provisioner/data
-:hierarchy:
-  - local
-  - "%{::event}"
-  - "%{::component}"
-  - common
-:logger: console
-:merge_behavior: native
-:deep_merge_options: {}
+version: 5
+defaults:
+  datadir: /opt/shinesolutions/aem-aws-stack-provisioner/data
+  data_hash: yaml_data
+hierarchy:
+  - name: "User defined hiera file"
+    path: local.yaml
+  - name: "Event hiera"
+    path: "%{::event}.yaml"
+  - name: "Component hiera"
+    path: "%{::component}.yaml"
+  - name: "Common hiera"
+    path: common.yaml


### PR DESCRIPTION
Update hiera configuration from version 3 to version 5.

https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/3

This version upgrade is necessary for the log improvement https://github.com/shinesolutions/aem-aws-stack-builder/issues/12