### PR TITLE
Disabled default timeout for command execution deploy on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 3.0.1
-*
+* Fix deploy on init timeout
 
 ### 3.0.0
 * Upgrade puppet-aem-resources to 3.x.x and puppet-aem-curator to 1.x.x for AEM 6.4 support 

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -200,6 +200,7 @@ class deploy_on_init (
       cwd         => $tmp_dir,
       command     => "${base_dir}/aem-tools/deploy-artifacts.sh deploy-artifacts-descriptor.json >>${log_dir}/puppet-deploy-artifacts-init.log 2>&1",
       onlyif      => "test `aws s3 ls s3://${data_bucket_name}/${stack_prefix}/deploy-artifacts-descriptor.json | wc -l` -eq 1",
+      timeout     => 0,
     }
   }
 


### PR DESCRIPTION
Disabled default timeout of 300 seconds for executing the deploy on init command.