### PR TITLE
Fix failing snapshot by increasing the max_attempts for boto3 client …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Renamed proxy_exceptions parameter to proxy_noproxy
 - Upgrade aem_curator to 1.10.0
+- Fix failing snapshot by increasing the max_attempts for boto3 client to 120 tries #121
 
 ## [3.5.0] - 2019-02-03
 

--- a/files/aws-tools/snapshot_backup.py
+++ b/files/aws-tools/snapshot_backup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys, os, logging, boto3, requests, textwrap
+from botocore.config import Config
 from time import sleep
 from ctypes import CDLL
 from socket import gethostname
@@ -243,6 +244,12 @@ if __name__ == '__main__':
     args = parse_args()
     set_logging_level(args.quiet, args.verbose, log)
     log.debug('Args: %r', args)
+
+    boto3_config = Config(
+        retries = {
+            'max_attempts': 120
+            }
+        )
 
     ec2      = boto3.resource('ec2')
     instance = ec2_instance()


### PR DESCRIPTION
Fix failing snapshot by increasing the max_attempts for boto3 client to 120 tries #121