### PR TITLE
Improvement/lock deps version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem 'inspec', '1.51.6'
-gem 'puppet-lint', require: false
-gem 'r10k'
-gem 'rubocop', require: false
-gem 'yaml-lint', require: false
+gem 'puppet-lint', '2.3.6', require: false
+gem 'r10k', '3.2.0', require: false
+gem 'rubocop', '0.68.1', require: false
+gem 'yaml-lint', '0.0.10', require: false

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,13 @@ deps-local:
 	rm -rf modules/aem_resources/*
 	rm -rf modules/aem_curator/*
 	rm -rf modules/simianarmy/*
+	if [ ! -d ./modules/aem ]; then mkdir ./modules/aem; fi
 	cp -R ../puppet-aem/* modules/aem/
+	if [ ! -d ./modules/aem_resources ]; then mkdir ./modules/aem_resources; fi
 	cp -R ../puppet-aem-resources/* modules/aem_resources/
+	if [ ! -d ./modules/aem_curator ]; then mkdir ./modules/aem_curator; fi
 	cp -R ../puppet-aem-curator/* modules/aem_curator/
+	if [ ! -d ./modules/simianarmy ]; then mkdir ./modules/simianarmy; fi
 	cp -R ../puppet-simianarmy/* modules/simianarmy/
 	# only needed while using shinesolutions/puppet-aem fork
 	# TODO: remove when switching back to bstopp/puppet-aem

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 
 # resolve dependencies from remote artifact registries
 deps:
-	gem install bundler
+	gem install bundler --version=2.0.1
 	bundle install --binstubs
 	bundle exec r10k puppetfile install --verbose --moduledir modules
 	bundle exec inspec vendor --overwrite


### PR DESCRIPTION
This MR locks down deps versions and fixes a simple bug causing integration tests to fail due to missing folders.