### PR TITLE
Fix error when disabling awslogs cronjobs to prevent awslogs from start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed error while disabling awslogs daemon cronjobs to prevent awslogs from restart [shinesolutions/aem-aws-stack-builder#311]
 
 ## [4.12.0] - 2019-08-15
 ### Changed

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -31,11 +31,11 @@ class publish (
       command => 'mkdir -p /tmp/shinesolutions/crons/awslogs',
       path    => $exec_path,
       before  => Exec['Enable awslogs CronJobs'],
-      onlyif  => '/usr/bin/test -f /etc/cron.d/awslogs*'
+      onlyif  => 'ls /etc/cron.d/awslogs*'
     } -> exec { 'Disable awslogs CronJobs':
       command => 'mv /etc/cron.d/awslogs* /tmp/shinesolutions/crons/awslogs/',
       path    => $exec_path,
-      onlyif  => '/usr/bin/test -f /etc/cron.d/awslogs*'
+      onlyif  => 'ls /etc/cron.d/awslogs*'
     } -> exec { 'Prevent awslogs service from restart':
       command => "systemctl disable --now --no-block ${$awslogs_service_name}",
       path    => $exec_path,
@@ -214,7 +214,7 @@ class update_awslogs (
   exec { 'Enable awslogs CronJobs':
     command => 'mv /tmp/shinesolutions/crons/awslogs/* /etc/cron.d/',
     path    => $exec_path,
-    onlyif  => '/usr/bin/test -e /tmp/shinesolutions/crons/awslogs',
+    onlyif  => 'ls /tmp/shinesolutions/crons/awslogs*',
     before  => Service[$awslogs_service_name]
   }
 


### PR DESCRIPTION
Fixed error while disabling awslogs daemon cronjobs to prevent awslogs 
from restart [shinesolutions/aem-aws-stack-builder#311]

With this PR the test for checking if the awslogs cronjobs exists switched from using `test` to use `ls` in the future.