### PR TITLE
Add script to subscribe cloudwatch logs to lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Add new CronJob to subscribe all Cloudwatch log groups of the stack to the provided Lambda function
+
 ## [4.16.0] - 2019-09-10
 ### Added
 - Added new hiera parameter for component author-standby [shinesolutions/puppet-aem-curator#141]

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -20,7 +20,7 @@ author_publish_dispatcher::volume_type: gp2
 
 author_publish_dispatcher::aem_password_retrieval_command: "%{hiera('common::aem_password_retrieval_command')}"
 author_publish_dispatcher::awslogs_config_path: "%{hiera('common::awslogs_config_path')}"
-
+author_publish_dispatcher::enable_cloudwatch_s3_Stream: "%{alias('orchestrator::enable_cloudwatch_s3_Stream')}"
 # Scheduled jobs
 action_scheduled_jobs::offline_compaction_snapshot_enable: "%{alias('aem_orchestrator::scheduled_jobs::enable::offline_compaction_snapshot')}"
 action_scheduled_jobs::offline_compaction_snapshot_weekday: "%{hiera('aem_orchestrator::scheduled_jobs::weekday::offline_compaction_snapshot')}"
@@ -38,6 +38,10 @@ action_scheduled_jobs::live_snapshot_enable: "%{alias('publish::scheduled_jobs::
 action_scheduled_jobs::live_snapshot_weekday: "%{hiera('publish::scheduled_jobs::weekday::live_snapshot')}"
 action_scheduled_jobs::live_snapshot_hour: "%{hiera('publish::scheduled_jobs::hour::live_snapshot')}"
 action_scheduled_jobs::live_snapshot_minute: "%{hiera('publish::scheduled_jobs::minute::live_snapshot')}"
+action_scheduled_jobs::cloudwatch_s3_stream_enable: "%{alias('orchestrator::enable_cloudwatch_s3_Stream')}"
+action_scheduled_jobs::cloudwatch_s3_Stream_weekday: "%{hiera('aem_orchestrator::scheduled_jobs::weekday::cloudwatch_s3_Stream')}"
+action_scheduled_jobs::cloudwatch_s3_Stream_hour: "%{hiera('aem_orchestrator::scheduled_jobs::hour::cloudwatch_s3_Stream')}"
+action_scheduled_jobs::cloudwatch_s3_Stream_minute: "%{hiera('aem_orchestrator::scheduled_jobs::minute::cloudwatch_s3_Stream')}"
 
 aem_curator::action_enable_crxde::aem_instances:
   - run_mode: author

--- a/data/orchestrator.yaml
+++ b/data/orchestrator.yaml
@@ -12,6 +12,10 @@ action_scheduled_jobs::offline_snapshot_enable: "%{alias('aem_orchestrator::sche
 action_scheduled_jobs::offline_snapshot_weekday: "%{hiera('aem_orchestrator::scheduled_jobs::weekday::offline_snapshot')}"
 action_scheduled_jobs::offline_snapshot_hour: "%{hiera('aem_orchestrator::scheduled_jobs::hour::offline_snapshot')}"
 action_scheduled_jobs::offline_snapshot_minute: "%{hiera('aem_orchestrator::scheduled_jobs::minute::offline_snapshot')}"
+action_scheduled_jobs::cloudwatch_s3_stream_enable: "%{alias('orchestrator::enable_cloudwatch_s3_Stream')}"
+action_scheduled_jobs::cloudwatch_s3_Stream_weekday: "%{hiera('aem_orchestrator::scheduled_jobs::weekday::cloudwatch_s3_Stream')}"
+action_scheduled_jobs::cloudwatch_s3_Stream_hour: "%{hiera('aem_orchestrator::scheduled_jobs::hour::cloudwatch_s3_Stream')}"
+action_scheduled_jobs::cloudwatch_s3_Stream_minute: "%{hiera('aem_orchestrator::scheduled_jobs::minute::cloudwatch_s3_Stream')}"
 
 aem_orchestrator::user: aem-orchestrator
 aem_orchestrator::jarfile_source: "s3://%{::data_bucket_name}/%{::stack_prefix}/aem-orchestrator-%{hiera('orchestrator::aem_orchestrator_version')}.jar"

--- a/files/aws-tools/cloudwatch_logs_subscription.py
+++ b/files/aws-tools/cloudwatch_logs_subscription.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+import boto3
+from botocore.config import Config
+import logging
+import os
+import sys
+from socket import gethostname
+from argparse import ArgumentParser
+import textwrap
+
+# setting up logger
+logging.basicConfig(
+    stream = sys.stdout,
+    format = '%(asctime)s ' + gethostname() + ' %(levelname)-8s %(message)s',
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    )
+logger = logging.getLogger(__name__)
+logger.setLevel(int(os.getenv('LOG_LEVEL', logging.INFO)))
+
+client = boto3.client('logs')
+
+
+def unwrap(txt):
+    return ' '.join(textwrap.wrap(textwrap.dedent(txt).strip()))
+
+def parse_args():
+    p = ArgumentParser(
+        description=unwrap("""
+            Subscribe AWS CloudWatch Log groups to LAMBDA.
+        """),
+    )
+    p.add_argument(
+        '--stack_prefix',
+        action  = 'store',
+        default = '',
+        metavar = 'StackABC',
+        help    = unwrap("""
+            The AEM StackPrefix.
+        """),
+    )
+    p.add_argument(
+        '--subscription_arn',
+        action  = 'store',
+        default = '',
+        metavar = 'arn:aws:lambda:*:*:function:*',
+        help    = unwrap("""
+            The AWS Lambda ARN to subscribe the log groups to.
+        """),
+    )
+
+    args = p.parse_args()
+    return args
+
+########################################################################
+# Get all log groups of log groups beginning with 'stack_prefix/'
+# and return a list of all found log groups
+########################################################################
+def get_log_groups(stack_prefix):
+    log_groups = {}
+
+    response = client.describe_log_groups(
+        logGroupNamePrefix=stack_prefix + '/',
+        limit=50
+    )
+
+    log_groups = response['logGroups']
+
+    if 'nextToken' in response:
+        while 'nextToken' in response:
+            response = client.describe_log_groups(
+                limit=50,
+                nextToken=response['nextToken'],
+                logGroupNamePrefix=stack_prefix + '/'
+            )
+            log_groups = log_groups + response['logGroups']
+    logger.debug('Found log groups: ')
+    logger.debug(log_groups)
+    return log_groups
+
+########################################################################
+# Return a list of all log_groups
+########################################################################
+def get_log_group_names(stack_prefix):
+    log_group_names = []
+
+    log_groups = get_log_groups(stack_prefix)
+    for log_group in log_groups:
+        log_group_names.append(log_group['logGroupName'])
+
+    logger.debug('Found log_groups: ')
+    logger.debug(log_group_names)
+    return log_group_names
+
+########################################################################
+# Return a list of the log group subscription filter
+########################################################################
+def get_subscribed_log_group(log_group_name):
+    subscribed_log_group = {}
+
+    response = client.describe_subscription_filters(
+        logGroupName=log_group_name,
+        limit=50
+    )
+
+    subscribed_log_group = response['subscriptionFilters']
+
+    if 'nextToken' in response:
+        while 'nextToken' in response:
+            response = client.describe_subscription_filters(
+                limit=50,
+                nextToken=response['nextToken'],
+                logGroupName=stack_prefix + '/'
+            )
+
+            subscribed_log_group = subscribed_log_group + response['logGroups']
+
+    logger.debug('Found subscribed log groups: ')
+    logger.debug(subscribed_log_group)
+    return subscribed_log_group
+
+########################################################################
+# Subscribe the provided log group
+########################################################################
+def subscribe_log_group(log_group_name, subscription_arn):
+    subscribed_log_group = {}
+
+
+    subscribed_log_group = get_subscribed_log_group(log_group_name)
+
+    if len(subscribed_log_group) < 1:
+
+        client.put_subscription_filter(
+            logGroupName=log_group_name,
+            filterName=log_group_name + '_CW-S3_Stream',
+            filterPattern='',
+            destinationArn=subscription_arn
+        )
+        logger.info('Log group ' + log_group_name + ' successfully subscribed')
+
+    else:
+        logger.info('Skip log group ' + log_group_name + '. Loggroup already subscribed.')
+
+if __name__ == '__main__':
+    args = parse_args()
+    stack_prefix = args.stack_prefix
+
+    # Always append :prod alias of the lambda function
+    subscription_arn = args.subscription_arn + ':prod'
+
+    logger.debug('Stack Prefix: ')
+    logger.debug(stack_prefix)
+    logger.debug('Lambda subscription ARN: ')
+    logger.debug(subscription_arn)
+
+    logger.info('Get log group names')
+    log_group_names = get_log_group_names(stack_prefix)
+
+    if len(log_group_names) > 0:
+        logger.info('Subscribe log groups to lambda function')
+        for log_group_name in log_group_names:
+            logger.debug('Subscribe log group: ' + log_group_name)
+            subscribe_log_group(log_group_name, subscription_arn)
+    else:
+        logger.info('No loggroups for subscription found.')
+        logger.info('Please check if stack name is correct.')

--- a/manifests/action-scheduled-jobs.pp
+++ b/manifests/action-scheduled-jobs.pp
@@ -14,9 +14,9 @@ class action_scheduled_jobs (
   $offline_compaction_snapshot_enable  = false,
   $offline_snapshot_enable             = false,
   $content_health_check_enable         = false,
-  $cloudwatch_s3_Stream_weekday        = '*',
-  $cloudwatch_s3_Stream_hour           = '*',
-  $cloudwatch_s3_Stream_minute         = '30',
+  $cloudwatch_s3_stream_weekday        = '*',
+  $cloudwatch_s3_stream_hour           = '*',
+  $cloudwatch_s3_stream_minute         = '30',
   $cloudwatch_log_subscription_arn     = '',
   $content_health_check_weekday        = '*',
   $content_health_check_hour           = '*',
@@ -142,9 +142,9 @@ class action_scheduled_jobs (
       ensure  => present,
       command => "${base_dir}/aws-tools/cloudwatch-s3-stream.sh ${stack_prefix} ${cloudwatch_log_subscription_arn} >>${log_dir}/cron-clouddwatch-log-s3-stream.log 2>&1",
       user    => 'root',
-      hour    => $cloudwatch_s3_Stream_hour,
-      minute  => $cloudwatch_s3_Stream_minute,
-      weekday => $cloudwatch_s3_Stream_weekday
+      hour    => $cloudwatch_s3_stream_hour,
+      minute  => $cloudwatch_s3_stream_minute,
+      weekday => $cloudwatch_s3_stream_weekday
     }
   } else {
     cron { 'clouddwatch-s3-stream':

--- a/manifests/action-scheduled-jobs.pp
+++ b/manifests/action-scheduled-jobs.pp
@@ -8,11 +8,16 @@ class action_scheduled_jobs (
   $http_proxy                          = $::cron_http_proxy,
   $https_proxy                         = $::cron_https_proxy,
   $no_proxy                            = $::cron_no_proxy,
+  $cloudwatch_s3_stream_enable         = false,
   $export_enable                       = false,
   $live_snapshot_enable                = false,
   $offline_compaction_snapshot_enable  = false,
   $offline_snapshot_enable             = false,
   $content_health_check_enable         = false,
+  $cloudwatch_s3_Stream_weekday        = '*',
+  $cloudwatch_s3_Stream_hour           = '*',
+  $cloudwatch_s3_Stream_minute         = '30',
+  $cloudwatch_log_subscription_arn     = '',
   $content_health_check_weekday        = '*',
   $content_health_check_hour           = '*',
   $content_health_check_minute         = '*',
@@ -28,7 +33,8 @@ class action_scheduled_jobs (
   $offline_snapshot_hour               = '1',
   $offline_snapshot_minute             = '15',
   $offline_snapshot_weekday            = '2-7',
-  $log_dir                             = '/var/log/shinesolutions'
+  $log_dir                             = '/var/log/shinesolutions',
+  $stack_prefix                        = $::stack_prefix,
 ) {
 
   # This dummy job is a placeholder just to import proxy environment variables once off
@@ -126,6 +132,24 @@ class action_scheduled_jobs (
     cron { 'content-health-check':
       ensure  => absent,
       command => "${base_dir}/aem-tools/content-healthcheck.py >>${log_dir}/cron-content-health-check.log 2>&1",
+      user    => 'root'
+    }
+  }
+
+  # CronJob for subscribing Stacks Cloudwatch logs to Lambda
+  if $cloudwatch_s3_stream_enable == true {
+    cron { 'clouddwatch-s3-stream':
+      ensure  => present,
+      command => "${base_dir}/aws-tools/cloudwatch-s3-stream.sh ${stack_prefix} ${cloudwatch_log_subscription_arn} >>${log_dir}/cron-clouddwatch-log-s3-stream.log 2>&1",
+      user    => 'root',
+      hour    => $cloudwatch_s3_Stream_hour,
+      minute  => $cloudwatch_s3_Stream_minute,
+      weekday => $cloudwatch_s3_Stream_weekday
+    }
+  } else {
+    cron { 'clouddwatch-s3-stream':
+      ensure  => absent,
+      command => "${base_dir}/aws-tools/cloudwatch-s3-stream.sh ${stack_prefix} ${cloudwatch_log_subscription_arn} >>${log_dir}/cron-clouddwatch-log-s3-stream.log 2>&1",
       user    => 'root'
     }
   }

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -21,7 +21,7 @@ class author_publish_dispatcher (
   $ec2_id                      = $::ec2_metadata['instance-id'],
   $log_dir                     = '/var/log/shinesolutions',
   $deploy_timeout              = 1200,
-  $enable_cloudwatch_s3_Stream = false,
+  $enable_cloudwatch_s3_stream = false,
 ) {
 
   $credentials_hash = loadjson("${tmp_dir}/${credentials_file}")
@@ -187,9 +187,9 @@ class author_publish_dispatcher (
   }
 
   ##############################################################################
-  # Cloudwatch to S3 Stream shell script
+  # Cloudwatch to S3 stream shell script
   ##############################################################################
-  if $enable_cloudwatch_s3_Stream {
+  if $enable_cloudwatch_s3_stream {
     file { "${base_dir}/aws-tools/cloudwatch-s3-stream.sh":
       ensure  => present,
       content => epp("${base_dir}/aem-aws-stack-provisioner/templates/aws-tools/cloudwatch-s3-stream.sh.epp",
@@ -204,7 +204,7 @@ class author_publish_dispatcher (
     }
 
     ##############################################################################
-    # Cloudwatch to S3 Stream python script
+    # Cloudwatch to S3 stream python script
     ##############################################################################
     file { "${base_dir}/aws-tools/cloudwatch_logs_subscription.py":
       ensure => present,

--- a/manifests/author-publish-dispatcher.pp
+++ b/manifests/author-publish-dispatcher.pp
@@ -13,14 +13,15 @@ class author_publish_dispatcher (
   $enable_deploy_on_init,
   $aem_repo_devices,
   $awslogs_config_path,
-  $component             = $::component,
-  $data_bucket_name      = $::data_bucket_name,
-  $stack_prefix          = $::stack_prefix,
-  $aem_tools_env_path    = '$PATH:/opt/puppetlabs/puppet/bin',
-  $aem_id_author_primary = 'author-primary',
-  $ec2_id                = $::ec2_metadata['instance-id'],
-  $log_dir               = '/var/log/shinesolutions',
-  $deploy_timeout        = 1200,
+  $component                   = $::component,
+  $data_bucket_name            = $::data_bucket_name,
+  $stack_prefix                = $::stack_prefix,
+  $aem_tools_env_path          = '$PATH:/opt/puppetlabs/puppet/bin',
+  $aem_id_author_primary       = 'author-primary',
+  $ec2_id                      = $::ec2_metadata['instance-id'],
+  $log_dir                     = '/var/log/shinesolutions',
+  $deploy_timeout              = 1200,
+  $enable_cloudwatch_s3_Stream = false,
 ) {
 
   $credentials_hash = loadjson("${tmp_dir}/${credentials_file}")
@@ -183,6 +184,35 @@ class author_publish_dispatcher (
       'tmp_dir'            => $tmp_dir
       }
     ),
+  }
+
+  ##############################################################################
+  # Cloudwatch to S3 Stream shell script
+  ##############################################################################
+  if $enable_cloudwatch_s3_Stream {
+    file { "${base_dir}/aws-tools/cloudwatch-s3-stream.sh":
+      ensure  => present,
+      content => epp("${base_dir}/aem-aws-stack-provisioner/templates/aws-tools/cloudwatch-s3-stream.sh.epp",
+      {
+        'aem_tools_env_path' => $aem_tools_env_path,
+        'base_dir'           => $base_dir,
+        }
+      ),
+      mode    => '0750',
+      owner   => 'root',
+      group   => 'root',
+    }
+
+    ##############################################################################
+    # Cloudwatch to S3 Stream python script
+    ##############################################################################
+    file { "${base_dir}/aws-tools/cloudwatch_logs_subscription.py":
+      ensure => present,
+      source => "file://${base_dir}/aem-aws-stack-provisioner/files/aws-tools/cloudwatch_logs_subscription.py",
+      mode   => '0750',
+      owner  => 'root',
+      group  => 'root',
+    }
   }
 
   ##############################################################################

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -6,11 +6,12 @@ class orchestrator (
   $base_dir,
   $tmp_dir,
   $awslogs_config_path,
-  $aem_tools_env_path       = '$PATH:/opt/puppetlabs/puppet/bin',
-  $stack_manager_stack_name = undef,
-  $data_bucket_name         = $::data_bucket_name,
-  $stack_prefix             = $::stack_prefix,
-  $component                = $::component,
+  $aem_tools_env_path          = '$PATH:/opt/puppetlabs/puppet/bin',
+  $stack_manager_stack_name    = undef,
+  $data_bucket_name            = $::data_bucket_name,
+  $stack_prefix                = $::stack_prefix,
+  $component                   = $::component,
+  $enable_cloudwatch_s3_Stream = false,
 ) {
 
   Archive {
@@ -79,6 +80,35 @@ class orchestrator (
     mode    => '0775',
     owner   => 'root',
     group   => 'root',
+  }
+
+  ##############################################################################
+  # Cloudwatch to S3 Stream shell script
+  ##############################################################################
+  if $enable_cloudwatch_s3_Stream {
+    file { "${base_dir}/aws-tools/cloudwatch-s3-stream.sh":
+      ensure  => present,
+      content => epp("${base_dir}/aem-aws-stack-provisioner/templates/aws-tools/cloudwatch-s3-stream.sh.epp",
+      {
+        'aem_tools_env_path' => $aem_tools_env_path,
+        'base_dir'           => $base_dir,
+        }
+      ),
+      mode    => '0750',
+      owner   => 'root',
+      group   => 'root',
+    }
+
+    ##############################################################################
+    # Cloudwatch to S3 Stream python script
+    ##############################################################################
+    file { "${base_dir}/aws-tools/cloudwatch_logs_subscription.py":
+      ensure => present,
+      source => "file://${base_dir}/aem-aws-stack-provisioner/files/aws-tools/cloudwatch_logs_subscription.py",
+      mode   => '0750',
+      owner  => 'root',
+      group  => 'root',
+    }
   }
 
   ##############################################################################

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -11,7 +11,7 @@ class orchestrator (
   $data_bucket_name            = $::data_bucket_name,
   $stack_prefix                = $::stack_prefix,
   $component                   = $::component,
-  $enable_cloudwatch_s3_Stream = false,
+  $enable_cloudwatch_s3_stream = false,
 ) {
 
   Archive {
@@ -83,9 +83,9 @@ class orchestrator (
   }
 
   ##############################################################################
-  # Cloudwatch to S3 Stream shell script
+  # Cloudwatch to S3 stream shell script
   ##############################################################################
-  if $enable_cloudwatch_s3_Stream {
+  if $enable_cloudwatch_s3_stream {
     file { "${base_dir}/aws-tools/cloudwatch-s3-stream.sh":
       ensure  => present,
       content => epp("${base_dir}/aem-aws-stack-provisioner/templates/aws-tools/cloudwatch-s3-stream.sh.epp",
@@ -100,7 +100,7 @@ class orchestrator (
     }
 
     ##############################################################################
-    # Cloudwatch to S3 Stream python script
+    # Cloudwatch to S3 stream python script
     ##############################################################################
     file { "${base_dir}/aws-tools/cloudwatch_logs_subscription.py":
       ensure => present,

--- a/templates/aws-tools/cloudwatch-s3-stream.sh.epp
+++ b/templates/aws-tools/cloudwatch-s3-stream.sh.epp
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+if [ "$#" -ne 2 ]; then
+  echo 'Usage: ./cloudwatch-s3-stream.sh <stack_prefix> <subscription_arn>'
+  exit 1
+fi
+
+# translate exit code to follow convention
+translate_exit_code() {
+  exit_code="$1"
+  if [ "$exit_code" -eq 0 ]; then
+    exit_code=0
+  else
+    exit "$exit_code"
+  fi
+
+  return "$exit_code"
+}
+
+stack_prefix=$1
+subscription_arn=$2
+
+PATH=<%= $aem_tools_env_path %>
+
+set +o errexit
+
+<%= $base_dir %>/aws-tools/cloudwatch_logs_subscription.py \
+  --stack_prefix "${stack_prefix}" \
+  --subscription_arn "${subscription_arn}" \
+
+translate_exit_code "$?"


### PR DESCRIPTION
This PR adds a new python and shell script to the orchestrator component to subscribe the Stacks Cloudwatch logs to the AEM Stack Manager cloudwatch log s3 stream lambda function. 

It uses the StackPrefix to determine all available logfiles in cloudwatch and subscribed them to the provided ARN of the Lambda function.

The Shell script is triggered via cron, default is every hour. 