### PR TITLE
Disable logrotation for awslogs on publisher during snapshot_attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Disable logrotation for awslogs logfiles on publisher during snapshot_attach process #194
+
 ## [4.19.0] - 2019-10-07
 ### Changed
 - Increase snapshot waiting timeout to 1 hour in snapshot_backup.py to handle encrypted volume


### PR DESCRIPTION
Disable logrotation for awslogs logfiles on publisher during snapshot_attach process #194

If a publish instance runs through the snapshot_attach process we are now also disabling the logrotation for awslogs, as in some cases the logrotation can happen during provisioning and it will restart the awslogs service. This PR prevents logrotation for awslogs before the snapshot_attach process and enables it afterwards.