### PR TITLE
Added new hiera parameters for enabling configuration of AEM agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Unreleased
+## Unreleased
+
+### Added
+- Added new hiera parameter `enable_remove_all_agents` with default value `true` to enable the removal of all AEM agents while configuring `author-primary` & `publish` [shinesolutions/puppet-aem-curator#149] [shinesolutions/puppet-aem-curator#150]
+- Added new hiera parameter `enable_create_flush_agents` with default value `true` to enable creation of the dispatcher flush agents while configuring `publish` [shinesolutions/puppet-aem-curator#149] [shinesolutions/puppet-aem-curator#150]
+- Added new hiera parameter `enable_create_outbox_replication_agents` with default value `true` to enable creation of the dispatcher replication agents while configuring `publish` [shinesolutions/puppet-aem-curator#149] [shinesolutions/puppet-aem-curator#150]
 
 ## [4.20.1] - 2019-10-17
 

--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -94,6 +94,9 @@ aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('au
 aem_curator::config_aem_scheduled_jobs::offline_compaction_hour: "%{hiera('author_primary::scheduled_jobs::hour::offline_compaction')}"
 aem_curator::config_aem_scheduled_jobs::offline_compaction_minute: "%{hiera('author_primary::scheduled_jobs::minute::offline_compaction')}"
 
+# Configure AEM Author Agents
+aem_curator::config_author_primary::enable_remove_all_agents: true
+
 # Logrotation configuration
 aem_curator::config_logrotate::config: "%{alias('author_primary::logrotation::config')}"
 aem_curator::config_logrotate::rules: "%{alias('author_primary::logrotation::rules')}"
@@ -126,4 +129,3 @@ aem_curator::config_author_primary::proxy_noproxy: "%{alias('common::proxy_nopro
 # Service start Post sleep configuration
 aem_curator::config_author_primary::enable_post_start_sleep: "%{alias('common::enable_post_start_sleep')}"
 aem_curator::config_author_primary::post_start_sleep_seconds: "%{hiera('common::post_start_sleep_seconds')}"
-

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -121,6 +121,9 @@ aem_curator::config_author_primary::certificate_key_arn: "%{hiera('common::certi
 aem_curator::config_author_primary::aem_system_users: "%{alias('common::aem_system_users')}"
 aem_curator::config_author_primary::data_volume_mount_point: /mnt/ebs1
 
+# Configure AEM Author Agents
+aem_curator::config_author_primary::enable_remove_all_agents: true
+
 # AEM Publish
 aem_curator::config_publish::publish_dispatcher_host: localhost
 aem_curator::config_publish::publish_dispatcher_id: localhost
@@ -148,6 +151,11 @@ aem_curator::config_publish::certificate_arn: "%{hiera('common::certificate_arn'
 aem_curator::config_publish::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
 aem_curator::config_publish::aem_system_users: "%{alias('common::aem_system_users')}"
 aem_curator::config_publish::data_volume_mount_point: /mnt/ebs2
+
+# Configure AEM Publish Agents
+aem_curator::config_publish::enable_create_flush_agents: true
+aem_curator::config_publish::enable_create_outbox_replication_agents: true
+aem_curator::config_publish::enable_remove_all_agents: true
 
 # AEM Publish-Dispatcher
 aem_curator::config_publish_dispatcher::dispatcher_conf_dir: "%{hiera('common::dispatcher_conf_dir')}"

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -90,6 +90,11 @@ aem_curator::config_publish::certificate_key_arn: "%{hiera('common::certificate_
 aem_curator::config_publish::aem_system_users: "%{alias('common::aem_system_users')}"
 aem_curator::config_publish::data_volume_mount_point: /mnt/ebs1
 
+# Configure AEM Publish Agents
+aem_curator::config_publish::enable_create_flush_agents: true
+aem_curator::config_publish::enable_create_outbox_replication_agents: true
+aem_curator::config_publish::enable_remove_all_agents: true
+
 aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('publish::scheduled_jobs::enable::offline_compaction')}"
 aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('publish::scheduled_jobs::weekday::offline_compaction')}"
 aem_curator::config_aem_scheduled_jobs::offline_compaction_hour: "%{hiera('publish::scheduled_jobs::hour::offline_compaction')}"


### PR DESCRIPTION
### Added
- Added new hiera parameter `enable_remove_all_agents` with default 
value `true` to enable the removal of all AEM agents while configuring 
`author-primary` & `publish` [shinesolutions/puppet-aem-curator#149] 
[shinesolutions/puppet-aem-curator#150]
- Added new hiera parameter `enable_create_flush_agents` with default 
value `true` to enable creation of the dispatcher flush agents while 
configuring `publish` [shinesolutions/puppet-aem-curator#149] 
[shinesolutions/puppet-aem-curator#150]
- Added new hiera parameter `enable_create_outbox_replication_agents` 
with default value `true` to enable creation of the dispatcher 
replication agents while configuring `publish` 
[shinesolutions/puppet-aem-curator#149] 
[shinesolutions/puppet-aem-curator#150]


This PR is needed to enable the agent handling during the provisioning.