### PR TITLE
Renamed hiera parameter for resolving the aem_system_users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Unreleased
 
+### Changed
+- Renamed hiera parameter for resolving the aem_system_users from `common::aem_system_users` to component specific hiera parameter `[author|publish]::aem_system_users` [shinesolutions/aem-aws-stack-builder#352]
+
 ## [4.20.1] - 2019-10-17
 
 ### Changed

--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -87,7 +87,7 @@ aem_curator::config_author_primary::aem_ssl_keystore_password: "%{hiera('common:
 aem_curator::config_author_primary::enable_aem_reconfiguration: "%{alias('common::enable_aem_reconfiguration')}"
 aem_curator::config_author_primary::certificate_arn: "%{hiera('common::certificate_arn')}"
 aem_curator::config_author_primary::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
-aem_curator::config_author_primary::aem_system_users: "%{alias('common::aem_system_users')}"
+aem_curator::config_author_primary::aem_system_users: "%{alias('author::aem_system_users')}"
 aem_curator::config_author_primary::data_volume_mount_point: /mnt/ebs1
 aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('author_primary::scheduled_jobs::enable::offline_compaction')}"
 aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('author_primary::scheduled_jobs::weekday::offline_compaction')}"

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -118,7 +118,7 @@ aem_curator::config_author_primary::aem_ssl_keystore_password: "%{hiera('common:
 aem_curator::config_author_primary::enable_aem_reconfiguration: "%{alias('common::enable_aem_reconfiguration')}"
 aem_curator::config_author_primary::certificate_arn: "%{hiera('common::certificate_arn')}"
 aem_curator::config_author_primary::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
-aem_curator::config_author_primary::aem_system_users: "%{alias('common::aem_system_users')}"
+aem_curator::config_author_primary::aem_system_users: "%{alias('author::aem_system_users')}"
 aem_curator::config_author_primary::data_volume_mount_point: /mnt/ebs1
 
 # AEM Publish
@@ -146,7 +146,7 @@ aem_curator::config_publish::aem_ssl_keystore_password: "%{hiera('common::aem_ss
 aem_curator::config_publish::enable_aem_reconfiguration: "%{alias('common::enable_aem_reconfiguration')}"
 aem_curator::config_publish::certificate_arn: "%{hiera('common::certificate_arn')}"
 aem_curator::config_publish::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
-aem_curator::config_publish::aem_system_users: "%{alias('common::aem_system_users')}"
+aem_curator::config_publish::aem_system_users: "%{alias('publish::aem_system_users')}"
 aem_curator::config_publish::data_volume_mount_point: /mnt/ebs2
 
 # AEM Publish-Dispatcher

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -87,7 +87,7 @@ aem_curator::config_publish::aem_ssl_keystore_password: "%{hiera('common::aem_ss
 aem_curator::config_publish::enable_aem_reconfiguration: "%{alias('common::enable_aem_reconfiguration')}"
 aem_curator::config_publish::certificate_arn: "%{hiera('common::certificate_arn')}"
 aem_curator::config_publish::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
-aem_curator::config_publish::aem_system_users: "%{alias('common::aem_system_users')}"
+aem_curator::config_publish::aem_system_users: "%{alias('publish::aem_system_users')}"
 aem_curator::config_publish::data_volume_mount_point: /mnt/ebs1
 
 aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('publish::scheduled_jobs::enable::offline_compaction')}"


### PR DESCRIPTION
Renamed hiera parameter for resolving the aem_system_users from `common::aem_system_users` to component specific hiera parameter `[author|publish]::aem_system_users` 

[shinesolutions/aem-aws-stack-builder#352]