### PR TITLE
Timeout tweaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Set exec timeout for attaching publish snapshot to the EC2 instance to `0`
+- Increase `snapshot_attach` timeout to 4h
+- Increase `snapshot_backup` timeout to 4h
+- Increase `wait_for_ec2tags` timeout to 720 retries
+
+### Removed
+- Remove parameter `snapshot_attach_timeout` in publish manifest
+
 ## [4.28.0] - 2020-01-28
 ### Changed
 - Upgrade puppet-aem-curator to 3.8.0

--- a/files/aws-tools/snapshot_attach.py
+++ b/files/aws-tools/snapshot_attach.py
@@ -415,7 +415,7 @@ if __name__ == '__main__':
 
     boto3_config = Config(
         retries = {
-            'max_attempts': 360
+            'max_attempts': 2880
             }
         )
 
@@ -441,8 +441,8 @@ if __name__ == '__main__':
                 snapshot.id,
             ],
             WaiterConfig={
-                'Delay': 15,
-                'MaxAttempts': 240
+                'Delay': 30,
+                'MaxAttempts': 480
             }
         )
         log.debug('Using snapshot %r', snapshot)

--- a/files/aws-tools/snapshot_backup.py
+++ b/files/aws-tools/snapshot_backup.py
@@ -247,7 +247,7 @@ if __name__ == '__main__':
 
     boto3_config = Config(
         retries = {
-            'max_attempts': 120
+            'max_attempts': 2880
             }
         )
 
@@ -298,15 +298,15 @@ if __name__ == '__main__':
 
     snapshot = start_snapshot(volume, log)
     tag_snapshot(snapshot, snapshot_tags)
-    
+
     # TODO: extract all Python logic here to a separate library, which can then be re-used along with snapshot attach logic
     ec2.meta.client.get_waiter('snapshot_completed').wait(
         SnapshotIds=[
             snapshot.id,
         ],
         WaiterConfig={
-            'Delay': 15,
-            'MaxAttempts': 240
+            'Delay': 30,
+            'MaxAttempts': 480
         }
     )
 

--- a/files/aws-tools/wait_for_ec2tags.py
+++ b/files/aws-tools/wait_for_ec2tags.py
@@ -3,7 +3,7 @@ import boto3, requests, sys
 from retrying import retry
 
 component = sys.argv[1]
-max_retries = 360
+max_retries = 720
 delay = 5000
 
 tag_keys = {

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -20,8 +20,7 @@ class publish (
   $aem_tools_env_path      = '$PATH:/opt/puppetlabs/puppet/bin',
   $https_proxy             = $::cron_https_proxy,
   $ec2_id                  = $::ec2_metadata['instance-id'],
-  $snapshotid              = $::snapshotid,
-  $snapshot_attach_timeout = 900,
+  $snapshotid              = $::snapshotid
 ) {
 
   # A simple check for checking if the awslogs(Cloudwatch Agent)
@@ -107,7 +106,7 @@ class publish (
 
     exec { "Attach volume from snapshot ID ${snapshotid}":
       command => "${base_dir}/aws-tools/snapshot_attach.py --device ${aem_repo_devices[0][device_name]} --device-alias ${aem_repo_devices[0][device_alias]} --volume-type ${volume_type} --snapshot-id ${snapshotid} -vvvv",
-      timeout => $snapshot_attach_timeout,
+      timeout => 0,
       path    => $exec_path,
       before  => Exec['Sleep 15 seconds before allowing access the mounted FS']
     }


### PR DESCRIPTION
 ### Changed
- Set exec timeout for attaching publish snapshot to the EC2 instance to `0`
- Increase `snapshot_attach` timeout to 4h
- Increase `snapshot_backup` timeout to 4h
- Increase `wait_for_ec2tags` timeout to 720 retries

### Removed
- Remove parameter `snapshot_attach_timeout` in publish manifest

