### PR TITLE
Support array hour for live_snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Changed
-- Support multi hours in the live-snaphsot scheduler
+- Add support for multi hours in the live-snaphsot scheduler
 
 ## [4.29.0] - 2020-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Support multi hours in the live-snaphsot scheduler
+
 ## [4.29.0] - 2020-03-01
 ### Added
 - Add awslogs.lock file removal to ensure awslogs nanny script does not start the service

--- a/manifests/action-scheduled-jobs.pp
+++ b/manifests/action-scheduled-jobs.pp
@@ -86,6 +86,7 @@ class action_scheduled_jobs (
   }
 
   if $live_snapshot_enable == true {
+    # The use of `split` in `hour` property is because array in yaml with alias is not supported. 
     cron { 'live-snapshot-backup':
       ensure  => present,
       command => "${base_dir}/aem-tools/live-snapshot-backup.sh >>${log_dir}/cron-live-snapshot-backup.log 2>&1",

--- a/manifests/action-scheduled-jobs.pp
+++ b/manifests/action-scheduled-jobs.pp
@@ -86,7 +86,7 @@ class action_scheduled_jobs (
   }
 
   if $live_snapshot_enable == true {
-    # The use of `split` in `hour` property is because array in yaml with alias is not supported. 
+    # The use of `split` in `hour` property is because array in yaml with alias is not supported.
     cron { 'live-snapshot-backup':
       ensure  => present,
       command => "${base_dir}/aem-tools/live-snapshot-backup.sh >>${log_dir}/cron-live-snapshot-backup.log 2>&1",

--- a/manifests/action-scheduled-jobs.pp
+++ b/manifests/action-scheduled-jobs.pp
@@ -90,7 +90,7 @@ class action_scheduled_jobs (
       ensure  => present,
       command => "${base_dir}/aem-tools/live-snapshot-backup.sh >>${log_dir}/cron-live-snapshot-backup.log 2>&1",
       user    => 'root',
-      hour    => $live_snapshot_hour,
+      hour    => split($live_snapshot_hour, ','),
       minute  => $live_snapshot_minute,
       weekday => $live_snapshot_weekday
     }


### PR DESCRIPTION
```
hour:
   - 0
   - 2-23
```
This config style is not supported by Puppet cron with alias. So the solution is to split the string by "," in the code. 
Note that there should not be any space in the string.
Here is the example.
`hour: "0,2-23"`