### PR TITLE
Enable SSL for JMX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added hiera parameters to enabale SSL for JMX for AEM Author & AEM Publish  #RS-124
+
+### Changed
+- Lockdowned version of `concurrent-ruby` to `1.1.9` #RS-126
+- Upgraded puppet-aem-curator to `3.32.0` #RS-124
 
 ## [6.0.0] - 2023-01-29
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'inspec', '1.51.6'
+gem 'concurrent-ruby', '1.1.9', require: false
 gem 'puppet', '~> 7.18', require: false
 gem 'puppetlabs_spec_helper', '4.0.1', require: false
 gem 'puppet-lint', '2.5.2', require: false

--- a/data/author-primary.yaml
+++ b/data/author-primary.yaml
@@ -95,6 +95,8 @@ aem_curator::config_author_primary::certificate_arn: "%{hiera('common::certifica
 aem_curator::config_author_primary::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
 aem_curator::config_author_primary::aem_system_users: "%{alias('author::aem_system_users')}"
 aem_curator::config_author_primary::data_volume_mount_point: /mnt/ebs1
+aem_curator::config_author_primary::jmxremote_enable_ssl: true
+aem_curator::config_author_primary::jmxremote_keystore_path: /etc/ssl/aem-author/jmx.ks
 aem_curator::config_aem_scheduled_jobs::offline_compaction_enable: "%{alias('author_primary::scheduled_jobs::enable::offline_compaction')}"
 aem_curator::config_aem_scheduled_jobs::offline_compaction_weekday: "%{hiera('author_primary::scheduled_jobs::weekday::offline_compaction')}"
 aem_curator::config_aem_scheduled_jobs::offline_compaction_hour: "%{hiera('author_primary::scheduled_jobs::hour::offline_compaction')}"

--- a/data/author-publish-dispatcher.yaml
+++ b/data/author-publish-dispatcher.yaml
@@ -128,6 +128,8 @@ aem_curator::config_author_primary::certificate_arn: "%{hiera('common::certifica
 aem_curator::config_author_primary::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
 aem_curator::config_author_primary::aem_system_users: "%{alias('author::aem_system_users')}"
 aem_curator::config_author_primary::data_volume_mount_point: /mnt/ebs1
+aem_curator::config_author_primary::jmxremote_enable_ssl: true
+aem_curator::config_author_primary::jmxremote_keystore_path: /etc/ssl/aem-author/jmx.ks
 
 # Configure AEM Author Agents
 aem_curator::config_author_primary::enable_remove_all_agents: true
@@ -162,6 +164,8 @@ aem_curator::config_publish::certificate_arn: "%{hiera('common::certificate_arn'
 aem_curator::config_publish::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
 aem_curator::config_publish::aem_system_users: "%{alias('publish::aem_system_users')}"
 aem_curator::config_publish::data_volume_mount_point: /mnt/ebs2
+aem_curator::config_publish::jmxremote_enable_ssl: true
+aem_curator::config_publish::jmxremote_keystore_path: /etc/ssl/aem-publish/jmx.ks
 
 # Configure AEM Publish Agents
 aem_curator::config_publish::enable_create_flush_agents: true

--- a/data/author-standby.yaml
+++ b/data/author-standby.yaml
@@ -72,6 +72,8 @@ aem_curator::config_author_standby::enable_deploy_flag: false
 aem_curator::config_author_standby::enable_crxde: false
 aem_curator::config_author_standby::enable_default_passwords: false
 aem_curator::config_author_standby::data_volume_mount_point: /mnt/ebs1
+aem_curator::config_author_standby::jmxremote_enable_ssl: true
+aem_curator::config_author_standby::jmxremote_keystore_path: /etc/ssl/aem-author/jmx.ks
 
 # Logrotation configuration
 aem_curator::config_logrotate::config: "%{alias('author_standby::logrotation::config')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -113,6 +113,9 @@ aem_curator::action_promote_author_standby_to_primary::login_ready_max_tries: "%
 aem_curator::action_promote_author_standby_to_primary::login_ready_base_sleep_seconds: "%{hiera('common::login_ready_base_sleep_seconds')}"
 aem_curator::action_promote_author_standby_to_primary::login_ready_max_sleep_seconds: "%{hiera('common::login_ready_max_sleep_seconds')}"
 
+# JMX Configuration
+aem_curator::action_promote_author_standby_to_primary::jmxremote_enable_ssl: true
+aem_curator::action_promote_author_standby_to_primary::jmxremote_keystore_path: /etc/ssl/aem-author/jmx.ks
 
 # AEM Scheduled jobs
 aem_curator::config_aem_scheduled_jobs::base_dir: "%{hiera('common::base_dir')}"

--- a/data/publish.yaml
+++ b/data/publish.yaml
@@ -92,6 +92,8 @@ aem_curator::config_publish::certificate_arn: "%{hiera('common::certificate_arn'
 aem_curator::config_publish::certificate_key_arn: "%{hiera('common::certificate_key_arn')}"
 aem_curator::config_publish::aem_system_users: "%{alias('publish::aem_system_users')}"
 aem_curator::config_publish::data_volume_mount_point: /mnt/ebs1
+aem_curator::config_publish::jmxremote_enable_ssl: true
+aem_curator::config_publish::jmxremote_keystore_path: /etc/ssl/aem-publish/jmx.ks
 
 # Configure AEM Publish Agents
 aem_curator::config_publish::enable_create_flush_agents: true


### PR DESCRIPTION
### Added
- Added hiera parameters to enabale SSL for JMX for AEM Author & AEM Publish  #RS-124

### Changed
- Lockdowned version of `concurrent-ruby` to `1.1.9` #RS-126
- Upgraded puppet-aem-curator to `3.32.0` #RS-124