### PR TITLE
Revert removal of default Apache httpd files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Revert removal of default Apache httpd files introduced in RS-138 #RS-139
 
 ## [6.4.0] - 2023-03-03
 ### Changed

--- a/manifests/pre-common.pp
+++ b/manifests/pre-common.pp
@@ -29,36 +29,6 @@ class pre_common (
     force  => yes,
   }
 
-  ########################################################################
-  ################################ RS-138 ################################
-  # Making sure that the default files of httpd do not exist,            #
-  # in case httpd got updated during bootup.                             #
-  # We do this to ensure that there is no correlation of the the httpd   #
-  # configuration files, set during AMI Baking & Package deployment.     #
-  # This ensures that httpd can be started successful.                   #
-  ########################################################################
-  file {'/etc/httpd/conf.d/ssl.conf':
-    ensure => absent,
-    force  => yes,
-  }
-  file {'/etc/httpd/conf.d/welcome.conf':
-    ensure => absent,
-    force  => yes,
-  }
-  file {'/etc/httpd/conf.d/userdir.conf':
-    ensure => absent,
-    force  => yes,
-  }
-  file {'/etc/httpd/conf.d/autoindex.conf':
-    ensure => absent,
-    force  => yes,
-  }
-  file {'/etc/httpd/conf.d/README':
-    ensure => absent,
-    force  => yes,
-  }
-
-
   $template_dir_final = pick(
     $template_dir,
     "${base_dir}/aem-aws-stack-provisioner/templates"


### PR DESCRIPTION
### Fixed
- Revert removal of default Apache httpd files introduced in RS-138 #RS-139