### PR TITLE
Simplify GitHub Actions release workflows to not use custom action

### DIFF
--- a/.github/actions/release-major-action/Dockerfile
+++ b/.github/actions/release-major-action/Dockerfile
@@ -1,3 +1,0 @@
-FROM ghcr.io/shinesolutions/the-works-buildenv:1.9.0
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-major-action/action.yaml
+++ b/.github/actions/release-major-action/action.yaml
@@ -1,4 +1,0 @@
-name: 'Release Major'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/actions/release-major-action/entrypoint.sh
+++ b/.github/actions/release-major-action/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-git config --global user.email "shineworks@shinesolutions.com"
-git config --global user.name "Shine Works"
-make release-major

--- a/.github/actions/release-minor-action/Dockerfile
+++ b/.github/actions/release-minor-action/Dockerfile
@@ -1,3 +1,0 @@
-FROM ghcr.io/shinesolutions/the-works-buildenv:1.9.0
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-minor-action/action.yaml
+++ b/.github/actions/release-minor-action/action.yaml
@@ -1,4 +1,0 @@
-name: 'Release Minor'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/actions/release-minor-action/entrypoint.sh
+++ b/.github/actions/release-minor-action/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-git config --global user.email "shineworks@shinesolutions.com"
-git config --global user.name "Shine Works"
-make release-minor

--- a/.github/actions/release-patch-action/Dockerfile
+++ b/.github/actions/release-patch-action/Dockerfile
@@ -1,3 +1,0 @@
-FROM ghcr.io/shinesolutions/the-works-buildenv:1.9.0
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-patch-action/action.yaml
+++ b/.github/actions/release-patch-action/action.yaml
@@ -1,4 +1,0 @@
-name: 'Release Patch'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/actions/release-patch-action/entrypoint.sh
+++ b/.github/actions/release-patch-action/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-git config --global user.email "shineworks@shinesolutions.com"
-git config --global user.name "Shine Works"
-make release-patch

--- a/.github/workflows/release-major-workflow.yaml
+++ b/.github/workflows/release-major-workflow.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: cliffano/release-action@v2.0.0
         with:
           release_type: major
-          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
           git_user_email: shinesworks@shinesolutions.com
           git_user_name: Shine Works

--- a/.github/workflows/release-major-workflow.yaml
+++ b/.github/workflows/release-major-workflow.yaml
@@ -3,17 +3,11 @@ name: Release Major
 on: [workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: docker/login-action@v1
+      - uses: cliffano/release-action@v2.0.0
         with:
-          registry: ghcr.io
-          username: shinesolutions
-          password: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-      - uses: ./.github/actions/release-major-action
-      - uses: ad-m/github-push-action@master
-        with:
-          tags: true
-          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          release_type: major
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-minor-workflow.yaml
+++ b/.github/workflows/release-minor-workflow.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: cliffano/release-action@v2.0.0
         with:
           release_type: minor
-          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
           git_user_email: shinesworks@shinesolutions.com
           git_user_name: Shine Works

--- a/.github/workflows/release-minor-workflow.yaml
+++ b/.github/workflows/release-minor-workflow.yaml
@@ -3,17 +3,11 @@ name: Release Minor
 on: [workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: docker/login-action@v1
+      - uses: cliffano/release-action@v2.0.0
         with:
-          registry: ghcr.io
-          username: shinesolutions
-          password: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-      - uses: ./.github/actions/release-minor-action
-      - uses: ad-m/github-push-action@master
-        with:
-          tags: true
-          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          release_type: minor
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-patch-workflow.yaml
+++ b/.github/workflows/release-patch-workflow.yaml
@@ -3,17 +3,11 @@ name: Release Patch
 on: [workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: docker/login-action@v1
+      - uses: cliffano/release-action@v2.0.0
         with:
-          registry: ghcr.io
-          username: shinesolutions
-          password: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-      - uses: ./.github/actions/release-patch-action
-      - uses: ad-m/github-push-action@master
-        with:
-          tags: true
-          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          release_type: patch
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-patch-workflow.yaml
+++ b/.github/workflows/release-patch-workflow.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: cliffano/release-action@v2.0.0
         with:
           release_type: patch
-          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
           git_user_email: shinesworks@shinesolutions.com
           git_user_name: Shine Works

--- a/.rtk.json
+++ b/.rtk.json
@@ -15,7 +15,7 @@
       "path": ".github/workflows/publish-workflow.yaml",
       "type": "yaml",
       "params": {
-        "property": "jobs.build.steps.0.with.ref",
+        "property": "jobs.build.steps[0].with.ref",
         "post_release_value": "main"
       }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Simplify GitHub Actions release workflows to not use custom action
+
 ## [7.2.3] - 2026-03-11
 ### Changed
 - Upgraded puppet-aem-curator to 4.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Simplify GitHub Actions release workflows to not use custom action
 
 ### Fixed
+- Fix release workflows to use SHINEOPENSOURCE_GITHUB_TOKEN instead of SHINEWORKS_GITHUB_TOKEN, matching this repo's original token
 - Fix .rtk.json jobs.build.steps property path to use array bracket notation (steps[0] instead of steps.0)
 
 ## [7.2.3] - 2026-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Simplify GitHub Actions release workflows to not use custom action
 
+### Fixed
+- Fix .rtk.json jobs.build.steps property path to use array bracket notation (steps[0] instead of steps.0)
+
 ## [7.2.3] - 2026-03-11
 ### Changed
 - Upgraded puppet-aem-curator to 4.1.9


### PR DESCRIPTION
## Summary
- Simplify GitHub Actions release workflows to not use custom action
- Fix .rtk.json property path to use array bracket notation
- Fix release workflow to use SHINEOPENSOURCE_GITHUB_TOKEN

Part of RS-204: uplift release workflows to the shared the-works-buildenv pattern.

## Test plan
- [ ] Confirm release-major/minor/patch workflows run correctly via workflow_dispatch after merge
